### PR TITLE
Removed preventDefault() that was breaking forms in overlay

### DIFF
--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -262,7 +262,6 @@ Overlay.prototype.close = function() {
 };
 
 Overlay.prototype.closeOnExternalClick = function(ev) {
-	ev.preventDefault();
 	if (!this.wrapper.contains(ev.target) && !this.opts.modal) {
 		this.close();
 	}


### PR DESCRIPTION
Fixes the regression mentioned in #73 
