### PR TITLE
#82: IE10 and IE11 does not support classList.remove with multiple parameters

### DIFF
--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -332,11 +332,10 @@ Overlay.prototype.respondToWindow = function(size) {
 	this.realign('width', size.width);
 	this.realign('height', size.height);
 
-	this.wrapper.classList.remove('o-overlay__arrow-top',
-		'o-overlay__arrow-bottom',
-		'o-overlay__arrow-left',
-		'o-overlay__arrow-right'
-	);
+	this.wrapper.classList.remove('o-overlay__arrow-top');
+	this.wrapper.classList.remove('o-overlay__arrow-bottom');
+	this.wrapper.classList.remove('o-overlay__arrow-left');
+	this.wrapper.classList.remove('o-overlay__arrow-right');
 
 	if (this.opts.arrow && !this.fills()) {
 		this.opts.arrow.currentposition = this.getCurrentArrowPosition(this.opts.arrow.position);


### PR DESCRIPTION
Fixes #82 