### PR TITLE
#84: Overlay arrow missing after resize to a screen width less than the width of the overlay

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -92,18 +92,10 @@
 
 	.#{$classname}--full-width {
 		@include oOverlayFullscreen($fill: 'width');
-
-		.#{$classname}__content {
-			@include oOverlayFullscreenContent();
-		}
 	}
 
 	.#{$classname}--full-height {
 		@include oOverlayFullscreen($fill: 'height');
-
-		.#{$classname}__content {
-			@include oOverlayFullscreenContent();
-		}
 	}
 }
 

--- a/main.scss
+++ b/main.scss
@@ -92,10 +92,18 @@
 
 	.#{$classname}--full-width {
 		@include oOverlayFullscreen($fill: 'width');
+
+		.#{$classname}__content {
+			@include oOverlayFullscreenContent();
+		}
 	}
 
 	.#{$classname}--full-height {
 		@include oOverlayFullscreen($fill: 'height');
+
+		.#{$classname}__content {
+			@include oOverlayFullscreenContent();
+		}
 	}
 }
 

--- a/src/scss/_fullscreen.scss
+++ b/src/scss/_fullscreen.scss
@@ -17,7 +17,3 @@
 		height: 100%;
 	}
 }
-
-@mixin oOverlayFullscreenContent() {
-	overflow: hidden;
-}

--- a/src/scss/_fullscreen.scss
+++ b/src/scss/_fullscreen.scss
@@ -7,8 +7,6 @@
 ///
 /// @param {String} fill - 'width' or 'height'
 @mixin oOverlayFullscreen($fill) {
-	overflow: hidden;
-
 	@if ($fill == 'width') {
 		padding-left: 0;
 		padding-right: 0;
@@ -18,4 +16,8 @@
 		padding-bottom: 0;
 		height: 100%;
 	}
+}
+
+@mixin oOverlayFullscreenContent() {
+	overflow: hidden;
 }


### PR DESCRIPTION
The overflow:hidden added by the full_width class hides the :before and :after elements (arrows). The overflow:hidden should be added to the content class only.
Fixes #84 