### PR TITLE
Add instance ID as BEM modifier to enable use as a styling hook

### DIFF
--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -146,6 +146,7 @@ Overlay.prototype.loadContent = function(callback) {
 Overlay.prototype.render = function() {
 	var wrapperEl = document.createElement('div');
 	wrapperEl.className = 'o-overlay';
+	wrapperEl.classList.add('o-overlay--' + this.id.replace(' ', '-'));
 	if (this.opts.zindex) {
 		wrapperEl.style.zIndex = this.opts.zindex;
 	}

--- a/test/specs/smoke-test.js
+++ b/test/specs/smoke-test.js
@@ -208,4 +208,15 @@ describe('smoke-tests (./overlay.js)', function() {
 			done();
 		});
 	});
+
+	it('should add the unique id as a CSS styling hook', function(done) {
+		var mod = new Overlay('testOverlay', {
+			html: testContent
+		});
+		mod.open();
+
+		var overlays = document.querySelectorAll('.o-overlay--testOverlay');
+		expect(overlays.length).toBe(1);
+		done();
+	});
 });

--- a/test/specs/smoke-test.js
+++ b/test/specs/smoke-test.js
@@ -210,12 +210,12 @@ describe('smoke-tests (./overlay.js)', function() {
 	});
 
 	it('should add the unique id as a CSS styling hook', function(done) {
-		var mod = new Overlay('testOverlay', {
+		var mod = new Overlay('test overlay', {
 			html: testContent
 		});
 		mod.open();
 
-		var overlays = document.querySelectorAll('.o-overlay--testOverlay');
+		var overlays = document.querySelectorAll('.o-overlay--test-overlay');
 		expect(overlays.length).toBe(1);
 		done();
 	});


### PR DESCRIPTION
This enables users of the component to override the default styling of the component using a modifier selector, if they wish too. A use-case we have on Next. 

/cc @AlbertoElias 