### PR TITLE
Move overlay wrapper focus to after overlay is setup

### DIFF
--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -251,7 +251,7 @@ Overlay.prototype.show = function() {
 	// Give the overlay focus
 	this.wrapper.setAttribute('tabindex', '0');
 	this.wrapper.style.outline = 0;
-	this.wrapper.focus();
+
 
 	// Renders content after overlay has been added so css is applied before that
 	// Thay way if an element has autofocus, the window won't scroll to the bottom
@@ -270,6 +270,7 @@ Overlay.prototype.show = function() {
 		overlay.height = overlay.getHeight();
 		overlay.respondToWindow(viewport.getSize());
 		overlay.visible = true;
+		overlay.wrapper.focus();
 		overlay.broadcast('ready');
 
 		// Add o-tracking integration


### PR DESCRIPTION
In Safari adding focus to the overlay wrapper was causing the page to jump to the bottom (see #104). I've moved where the focus is added now to after the wrapper has been displayed to prevent the jump.

Fixes #104 