### PR TITLE
Add: option to prevent closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ var myOverlay = new Overlay('myOverlay', {
 * `html`: String or HTMLElement.  Raw HTML (cannot be set declaratively)
 * `trigger`: String or HTMLElement. querySelector expression or HTMLElement. When there's a trigger set, a click event handler will be added to it that will open or close the overlay accordingly. (cannot be set declaratively)
 * `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '10'
+* `preventClosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.
 

--- a/demos/src/modal-prevent-closure.mustache
+++ b/demos/src/modal-prevent-closure.mustache
@@ -1,0 +1,23 @@
+<h2>Overlay triggers </h2>
+<button class="o-overlay-trigger" data-o-overlay-id="overlay" data-o-overlay-src="#overlay" data-o-overlay-heading-title="Overlay" data-o-overlay-heading-shaded="true" data-o-overlay-modal="true" data-o-overlay-preventclosing="true" data-o-overlay-zIndex="20" aria-pressed="false" aria-haspopup="true">Launch overlay</button>
+
+<script type="text/template" id="overlay">
+	<p>Overlay content.</p>
+	<p>Overlay content.</p>
+	<input id="username" />
+	<br>
+	<input id="password" type="password" />
+	<p>Overlay content.</p>
+	<p>Overlay content.</p>
+	<p>Overlay content.</p>
+	<p>Overlay content.</p>
+	<input id="username" />
+	<br>
+	<input id="pasword" type="password" />
+	<p>Overlay content.</p>
+	<p>Overlay content.</p>
+	<br>
+	<p>The preventclosing option suppresses all ways of closing the overlay, so you can specify an action in the html, such as a button / link.</p>
+	<br>
+	<button onclick="window.location.reload(true)">Close this overlay</button>
+</script>

--- a/origami.json
+++ b/origami.json
@@ -30,6 +30,11 @@
 			"template": "/demos/src/modal.mustache"
 		},
 		{
+			"name": "modal-prevent-closure",
+			"description": "Modal shaded overlay with standard closure prevented",
+			"template": "/demos/src/modal-prevent-closure.mustache"
+		},
+		{
 			"name": "centered-overlay",
 			"template": "/demos/src/centered-overlay.mustache",
 			"description": "Non-modal non-shaded centered overlay"

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -55,8 +55,8 @@ const checkOptions = function(opts) {
 		}
 
 		// Prevent closing is only available with modal
-		if (opts.preventClosing && !opts.modal) {
-			opst.preventClosing = false;
+		if (opts.preventclosing && !opts.modal) {
+			opts.preventclosing = false;
 		}
 	}
 
@@ -185,7 +185,7 @@ Overlay.prototype.render = function() {
 			heading.classList.add('o-overlay__heading--shaded');
 		}
 
-		if (!this.opts.preventClosing) {
+		if (!this.opts.preventclosing) {
 			const button = document.createElement('a');
 			button.className = 'o-overlay__close';
 			button.setAttribute('role', 'button');
@@ -334,7 +334,7 @@ Overlay.prototype.closeOnExternalClick = function(ev) {
 };
 
 Overlay.prototype.closeOnEscapePress = function(ev) {
-	if (!this.opts.preventClosing && ev.keyCode === 27) {
+	if (!this.opts.preventclosing && ev.keyCode === 27) {
 		this.close();
 	}
 };

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -53,6 +53,11 @@ const checkOptions = function(opts) {
 		} else if (!(opts.arrow.target instanceof HTMLElement)) {
 			opts.arrow.target = document.querySelector(opts.arrow.target);
 		}
+
+		// Prevent closing is only available with modal
+		if (opts.preventClosing && !opts.modal) {
+			opst.preventClosing = false;
+		}
 	}
 
 	return opts;
@@ -180,20 +185,22 @@ Overlay.prototype.render = function() {
 			heading.classList.add('o-overlay__heading--shaded');
 		}
 
-		const button = document.createElement('a');
-		button.className = 'o-overlay__close';
-		button.setAttribute('role', 'button');
-		button.setAttribute('tabindex', '0');
-		button.setAttribute('href', '#void');
-		button.setAttribute('aria-label', 'Close');
-		button.setAttribute('title', 'Close');
+		if (!this.opts.preventClosing) {
+			const button = document.createElement('a');
+			button.className = 'o-overlay__close';
+			button.setAttribute('role', 'button');
+			button.setAttribute('tabindex', '0');
+			button.setAttribute('href', '#void');
+			button.setAttribute('aria-label', 'Close');
+			button.setAttribute('title', 'Close');
+			heading.appendChild(button);
+		}
 
 		const title = document.createElement('span');
 		title.setAttribute('role', 'heading');
 		title.className = 'o-overlay__title';
 		title.innerHTML = this.opts.heading.title;
 
-		heading.appendChild(button);
 		heading.appendChild(title);
 		wrapperEl.appendChild(heading);
 	}
@@ -327,7 +334,7 @@ Overlay.prototype.closeOnExternalClick = function(ev) {
 };
 
 Overlay.prototype.closeOnEscapePress = function(ev) {
-	if (ev.keyCode === 27) {
+	if (!this.opts.preventClosing && ev.keyCode === 27) {
 		this.close();
 	}
 };

--- a/test/specs/overlay.test.js
+++ b/test/specs/overlay.test.js
@@ -280,6 +280,9 @@ describe("smoke-tests (./overlay.js)", () => {
 	});
 
 	it('should be able to inject content from a url', done => {
+		// Increase the timeout of this function to allow for the fetching of the url
+		this.timeout(10000);
+
 		const mod = new Overlay('testOverlay', {
 			src: 'https://www.ft.com/__origami/service/build/v2/files/o-card@2.2.3/demos/standard.html',
 			trigger: document.querySelector('.o-overlay-trigger')

--- a/test/specs/overlay.test.js
+++ b/test/specs/overlay.test.js
@@ -162,7 +162,7 @@ describe("smoke-tests (./overlay.js)", () => {
 			});
 			o.fireCustomEvent(document.body, 'oLayers.new', {el: 'something'});
 
-			// expect(Overlay.prototype.close.callCount).to.be(4);
+			expect(Overlay.prototype.close.callCount).to.be(4);
 
 			Overlay.prototype.close = realCloseFunction;
 			currentOverlay.close();
@@ -281,7 +281,7 @@ describe("smoke-tests (./overlay.js)", () => {
 
 	it('should be able to inject content from a url', done => {
 		const mod = new Overlay('testOverlay', {
-			src: 'https://origami-build.ft.com/files/o-card@2.2.3/demos/standard.html',
+			src: 'https://www.ft.com/__origami/service/build/v2/files/o-card@2.2.3/demos/standard.html',
 			trigger: document.querySelector('.o-overlay-trigger')
 		});
 

--- a/test/specs/overlay.test.js
+++ b/test/specs/overlay.test.js
@@ -81,8 +81,6 @@ describe("smoke-tests (./overlay.js)", () => {
 			const overlays = Overlay.init();
 			const currentOverlay = overlays[0];
 
-			o.fireEvent(trigger, 'click');
-
 			function overlayReadyHandler() {
 				o.fireEvent(document.querySelector('.o-overlay__close'), 'click');
 				o.fireEvent(document.body, 'click');
@@ -90,7 +88,6 @@ describe("smoke-tests (./overlay.js)", () => {
 					keyCode: 27
 				});
 				o.fireCustomEvent(document.body, 'oLayers.new');
-
 				expect(Overlay.prototype.close.callCount).to.be(3);
 
 				Overlay.prototype.close = realCloseFunction;
@@ -101,7 +98,50 @@ describe("smoke-tests (./overlay.js)", () => {
 			}
 
 			document.body.addEventListener('oOverlay.ready', overlayReadyHandler);
+			o.fireEvent(trigger, 'click');
+
 		});
+
+		it('modal with prevent closing should not be closable with esc key, close button, but can with new layer ', done => {
+
+			const realCloseFunction = Overlay.prototype.close;
+			const stubbedCloseFunction = sinon.stub();
+			Overlay.prototype.close = stubbedCloseFunction;
+
+			const trigger = document.querySelector('.o-overlay-trigger');
+			trigger.setAttribute('data-o-overlay-preventclosing', true);
+
+			const overlays = Overlay.init();
+			const currentOverlay = overlays[0];
+
+			function overlayReadyHandler() {
+				const overlayClose = document.querySelector('.o-overlay__close');
+				if (overlayClose) {
+					o.fireEvent(document.querySelector('.o-overlay__close'), 'click');
+				}
+				o.fireEvent(document.body, 'click');
+				o.fireEvent(document.body, 'keyup', {
+					keyCode: 27
+				});
+
+				expect(Overlay.prototype.close.callCount).to.be(0);
+
+				o.fireCustomEvent(document.body, 'oLayers.new');
+
+				expect(Overlay.prototype.close.callCount).to.be(1);
+
+				Overlay.prototype.close = realCloseFunction;
+				currentOverlay.close();
+
+				document.body.removeEventListener('oOverlay.ready', overlayReadyHandler);
+				done();
+			}
+
+			document.body.addEventListener('oOverlay.ready', overlayReadyHandler);
+			o.fireEvent(trigger, 'click');
+
+		});
+
 
 		it('non-modal should be closable in different ways', function() {
 			const realCloseFunction = Overlay.prototype.close;
@@ -115,7 +155,6 @@ describe("smoke-tests (./overlay.js)", () => {
 			const currentOverlay = overlays[0];
 
 			o.fireEvent(trigger, 'click');
-
 			o.fireEvent(document.querySelector('.o-overlay__close'), 'click');
 			o.fireEvent(document.body, 'click');
 			o.fireEvent(document.body, 'keyup', {
@@ -123,7 +162,7 @@ describe("smoke-tests (./overlay.js)", () => {
 			});
 			o.fireCustomEvent(document.body, 'oLayers.new', {el: 'something'});
 
-			expect(Overlay.prototype.close.callCount).to.be(4);
+			// expect(Overlay.prototype.close.callCount).to.be(4);
 
 			Overlay.prototype.close = realCloseFunction;
 			currentOverlay.close();

--- a/test/specs/overlay.test.js
+++ b/test/specs/overlay.test.js
@@ -8,7 +8,7 @@ const expect = require('expect.js');
 
 const sinon = require('sinon/pkg/sinon');
 
-describe("smoke-tests (./overlay.js)", () => {
+describe("smoke-tests (./overlay.js)", function() {
 
 	afterEach(() => {
 		Overlay.destroy();


### PR DESCRIPTION
cc: @onishiweb 

For ad-blocking we will want to have a modal overlay that can not be closed, forcing the user to take an action specified in the html.

The objective of this PR is to handle an option (`preventclosing`), that is only compatible with modal overlays.

It suppresses the header close function (eg. the `x`) as well as the escape click to close.

Have added a test to prove that preventclosing works.