### PR TITLE
Amend: Allow custom close in overlay html

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ var myOverlay = new Overlay('myOverlay', {
 * `html`: String or HTMLElement.  Raw HTML (cannot be set declaratively)
 * `trigger`: String or HTMLElement. querySelector expression or HTMLElement. When there's a trigger set, a click event handler will be added to it that will open or close the overlay accordingly. (cannot be set declaratively)
 * `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '10'
-* `preventClosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
+* `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
+* `customclose`: Boolean. If you do not use the header, but are provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ var myOverlay = new Overlay('myOverlay', {
 * `trigger`: String or HTMLElement. querySelector expression or HTMLElement. When there's a trigger set, a click event handler will be added to it that will open or close the overlay accordingly. (cannot be set declaratively)
 * `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '10'
 * `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
-* `customclose`: Boolean. If you do not use the header, but are provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
+* `customclose`: Boolean. If you do not use the header, but want to provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.
 

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -249,7 +249,7 @@ Overlay.prototype.show = function() {
 	this.closeOnNewLayerHandler = this.closeOnNewLayer.bind(this);
 	this.delegates.context.on('oLayers.new', this.closeOnNewLayerHandler);
 
-	if (this.opts.heading || this.opts.tooltip) {
+	if (this.opts.heading || this.opts.tooltip || this.opts.customclose) {
 		this.delegates.wrap.on('click', '.o-overlay__close', this.closeHandler);
 		this.delegates.wrap.on('touchend', '.o-overlay__close', this.closeHandler);
 	}


### PR DESCRIPTION
@onishiweb 

Adam,

Was thinking through how best to achieve the ability to have a close button without a header & title.

Simplest seems to be this;
- Create a customised close button in the html for the overlay that I pass through to o-overlay (using the o-overlay__close class on it)
- Pass a `customclose=true` option through so that it then puts the right close handling functionality onto it.

This causes no disruption to any existing use cases, but gives the flexibility that I'm looking for.
