### PR TITLE
Add handling for containers / custom titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ var myOverlay = new Overlay('myOverlay', {
 * `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '10'
 * `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
 * `customclose`: Boolean. If you do not use the header, but want to provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
+* `parentNode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the body or target
+* `nested`: Boolean. If set, the resize listeners will not be set up. This boolean should be used in conjunction with the `parentNode` setting to allow an overlay to be positioned within a dom element rather than overlaid on top of everything.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ var myOverlay = new Overlay('myOverlay', {
 
 * `heading`: Object. Options for the Overlay header
 	* `.title`: String. Your overlay's title
-	* `.visuallyHideTitle`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling)
+	* `.visuallyHideTitle`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling) Defaults to false.
 	* `.shaded`: Boolean. Whether to shade the background of the header
 * `arrow`: Object. Options for the arrow
 	* `.position`: String. From which side of the overlay should the arrow protrude. It has to be 'top', 'bottom', 'left' or 'right'. _Default_: 'left'

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ var myOverlay = new Overlay('myOverlay', {
 * `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '10'
 * `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
 * `customclose`: Boolean. If you do not use the header, but want to provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
-* `parentNode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the body or target
-* `nested`: Boolean. If set, the resize listeners will not be set up. This boolean should be used in conjunction with the `parentNode` setting to allow an overlay to be positioned within a dom element rather than overlaid on top of everything.
+* `parentNode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target.
+* `nested`: Boolean. If set to true, the resize listeners will not be set up. This boolean should be used in conjunction with the `parentNode` setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. Defaults to false.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ var myOverlay = new Overlay('myOverlay', {
 * `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '10'
 * `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
 * `customclose`: Boolean. If you do not use the header, but want to provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
-* `parentNode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target.
+* `parentNode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the `body` will be used.
 * `nested`: Boolean. If set to true, the resize listeners will not be set up. This boolean should be used in conjunction with the `parentNode` setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. Defaults to false.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ var myOverlay = new Overlay('myOverlay', {
 
 * `heading`: Object. Options for the Overlay header
 	* `.title`: String. Your overlay's title
-	* `.visuallyHideTitle`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling) Defaults to false.
+	* `.visuallyHideTitle`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling) _Default_: false.
 	* `.shaded`: Boolean. Whether to shade the background of the header
 * `arrow`: Object. Options for the arrow
 	* `.position`: String. From which side of the overlay should the arrow protrude. It has to be 'top', 'bottom', 'left' or 'right'. _Default_: 'left'
@@ -77,7 +77,7 @@ var myOverlay = new Overlay('myOverlay', {
 * `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
 * `customclose`: Boolean. If you do not use the header, but want to provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
 * `parentNode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the `body` will be used.
-* `nested`: Boolean. If set to true, the resize listeners will not be set up. This boolean should be used in conjunction with the `parentNode` setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. Defaults to false.
+* `nested`: Boolean. If set to true, the resize listeners will not be set up. This boolean should be used in conjunction with the `parentNode` setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. _Default_: false.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ var myOverlay = new Overlay('myOverlay', {
 
 * `heading`: Object. Options for the Overlay header
 	* `.title`: String. Your overlay's title
+	* `.visuallyHideTitle`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling)
 	* `.shaded`: Boolean. Whether to shade the background of the header
 * `arrow`: Object. Options for the arrow
 	* `.position`: String. From which side of the overlay should the arrow protrude. It has to be 'top', 'bottom', 'left' or 'right'. _Default_: 'left'

--- a/demos/src/sliding-notification.js
+++ b/demos/src/sliding-notification.js
@@ -1,0 +1,16 @@
+import Overlay from '../../main';
+
+document.addEventListener("DOMContentLoaded", function() {
+	let myOverlay = new Overlay('demoOverlay', {
+		nested: 'true',
+		parentNode: '.right-rail',
+		modal: false,
+		compact: true,
+		preventclosing: false,
+		heading: {title: 'hello'},
+		html: `<p>We're currently experiencing some technical difficulties. Some features may not work while we fix this problem.</p>
+					<button onclick="window.location.reload(true)" class="o-buttons">OK</button>`
+	});
+
+	myOverlay.open();
+});

--- a/demos/src/sliding-notification.js
+++ b/demos/src/sliding-notification.js
@@ -7,9 +7,11 @@ document.addEventListener("DOMContentLoaded", function() {
 		modal: false,
 		compact: true,
 		preventclosing: false,
-		heading: {title: 'hello'},
-		html: `<p>We're currently experiencing some technical difficulties. Some features may not work while we fix this problem.</p>
-					<button onclick="window.location.reload(true)" class="o-buttons">OK</button>`
+		addCloseBtn: true,
+		heading: { title: "Take a survey", visuallyHideTitle: true },
+		html: `<div class='demo-overlay-content'><span class='title'>How do you rate FT.com?</span><p>Take our short survey and be in with a chance to win £250</p>
+					<button onclick="window.location.reload(true)" class="o-buttons o-buttons--standout">Take survey</button>
+					<p class="small">T&Cs apply</p></div>`
 	});
 
 	myOverlay.open();

--- a/demos/src/sliding-notification.js
+++ b/demos/src/sliding-notification.js
@@ -1,7 +1,7 @@
 import Overlay from '../../main';
 
 document.addEventListener("DOMContentLoaded", function() {
-	let myOverlay = new Overlay('demoOverlay', {
+	let myOverlay = new Overlay('demo-overlay', {
 		nested: 'true',
 		parentNode: '.right-rail',
 		modal: false,

--- a/demos/src/sliding-notification.mustache
+++ b/demos/src/sliding-notification.mustache
@@ -1,5 +1,5 @@
 <div class='content'>
-	<div class='blur'>
+	<div class='blur left'>
 
 		<h2>What is Lorem Ipsum?</h2>
 		<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>

--- a/demos/src/sliding-notification.mustache
+++ b/demos/src/sliding-notification.mustache
@@ -1,0 +1,13 @@
+<div class='content'>
+	<div class='blur'>
+
+		<h2>What is Lorem Ipsum?</h2>
+		<p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+
+		<h2>Why do we use it?</h2>
+		<p>It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).</p>
+	</div>
+	<div class='right-rail'>
+		<p>Hello! this is the right rail</p>
+	</div>
+</div>

--- a/demos/src/sliding-notification.scss
+++ b/demos/src/sliding-notification.scss
@@ -9,19 +9,21 @@ body {
 .content {
 	margin: auto;
 	max-width: 1200px;
+
+	.left {
+		float: left;
+		width: 60%;
+		padding: 1em;
+		max-width: 900px;
+	}
+	.right-rail {
+		min-width: 200px;
+		width: 30%;
+		float: right;
+		height: 600px;
+	}
 }
-.content > .blur {
-	float: left;
-	width: 60%;
-	padding: 1em;
-	max-width: 900px;
-}
-.right-rail {
-	min-width: 200px;
-	width: 30%;
-	float: right;
-	height: 600px;
-}
+
 .blur {
 	color: transparent;
 	text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
@@ -29,4 +31,15 @@ body {
 .o-overlay--demo-overlay {
 	position: relative;
 	/* Other custom styles for animating can hang on this class */
+	text-align: center;
+}
+
+.demo-overlay-content {
+	padding: 0px 10px;
+	.small {
+		font-size: 12px;
+	}
+	.title {
+		font-weight: 500;
+	}
 }

--- a/demos/src/sliding-notification.scss
+++ b/demos/src/sliding-notification.scss
@@ -11,22 +11,22 @@ body {
 	max-width: 1200px;
 }
 .content > .blur {
-	float:left;
+	float: left;
 	width: 60%;
 	padding: 1em;
-	max-width: 900px
+	max-width: 900px;
 }
 .right-rail {
 	min-width: 200px;
 	width: 30%;
 	float: right;
-	height: 600px
+	height: 600px;
 }
 .blur {
 	color: transparent;
-	text-shadow: 0 0 5px rgba(0,0,0,0.5);
+	text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 }
-.o-overlay--demoOverlay {
+.o-overlay--demo-overlay {
 	position: relative;
 	/* Other custom styles for animating can hang on this class */
 }

--- a/demos/src/sliding-notification.scss
+++ b/demos/src/sliding-notification.scss
@@ -1,0 +1,32 @@
+$o-overlay-is-silent: false;
+@import "../../main";
+
+body {
+	font-family: MetricWeb;
+	padding: 10px;
+	min-height: 500px;
+}
+.content {
+	margin: auto;
+	max-width: 1200px;
+}
+.content > .blur {
+	float:left;
+	width: 60%;
+	padding: 1em;
+	max-width: 900px
+}
+.right-rail {
+	min-width: 200px;
+	width: 30%;
+	float: right;
+	height: 600px
+}
+.blur {
+	color: transparent;
+	text-shadow: 0 0 5px rgba(0,0,0,0.5);
+}
+.o-overlay--demoOverlay {
+	position: relative;
+	/* Other custom styles for animating can hang on this class */
+}

--- a/origami.json
+++ b/origami.json
@@ -43,6 +43,15 @@
 			"description": "Tooltip for annotating bits of UI",
 			"template": "/demos/src/tooltip.mustache",
 			"sass": "demos/src/tooltip.scss"
+		},
+		{
+			"name": "sliding-notification",
+			"title": "An overlay that slides into view",
+			"description": "O-overlay can also be used to create notifications that slide into view.",
+			"template": "/demos/src/sliding-notification.mustache",
+			"sass": "demos/src/sliding-notification.scss",
+			"js": "demos/src/sliding-notification.js"
+
 		}
 	]
 }

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -9,11 +9,6 @@ const checkOptions = function(opts) {
 		opts.trigger = document.querySelector(opts.trigger);
 	}
 
-	// There can't be a heading with an empty title
-	if (opts.heading && (!opts.heading.title || !opts.heading.title.trim())) {
-		throw new Error('"o-overlay error": To have a heading, a non-empty title needs to be set');
-	}
-
 	// Overlays that don't point at anything should be modal by default
 	if (!opts.arrow && typeof opts.modal === 'undefined') {
 		opts.modal = true;
@@ -203,7 +198,10 @@ Overlay.prototype.render = function() {
 		const title = document.createElement('span');
 		title.setAttribute('role', 'heading');
 		title.className = 'o-overlay__title';
-		title.innerHTML = this.opts.heading.title;
+
+		if (!this.opts.heading.visuallyHideTitle) {
+			title.innerHTML = this.opts.heading.title;
+		}
 
 		heading.appendChild(title);
 		wrapperEl.appendChild(heading);

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -111,7 +111,7 @@ const Overlay = function(id, opts) {
 		this.opts.trigger.addEventListener('click', triggerClickHandler.bind(this.opts.trigger, id), false);
 		this.context = this.opts.arrow ? oLayers.getLayerContext(this.opts.arrow.target) : oLayers.getLayerContext(this.opts.trigger);
 	} else {
-		if (this.opts.parentNode) {
+		if (document.querySelector(this.opts.parentNode)) {
 			this.context = document.querySelector(this.opts.parentNode);
 		} else {
 			this.context = this.opts.arrow ? oLayers.getLayerContext(this.opts.arrow.target) : document.body;

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -292,7 +292,11 @@ Overlay.prototype.show = function() {
 		}
 		overlay.width = overlay.getWidth();
 		overlay.height = overlay.getHeight();
-		if (!overlay.opts.nested) { overlay.respondToWindow(viewport.getSize()); }
+
+		// If the overlay is nested within a DOM element don't attach the viewport resize listeners
+		if (!overlay.opts.nested) {
+			overlay.respondToWindow(viewport.getSize());
+		}
 		overlay.visible = true;
 		overlay.wrapper.focus();
 		overlay.broadcast('ready');

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -9,6 +9,10 @@ const checkOptions = function(opts) {
 		opts.trigger = document.querySelector(opts.trigger);
 	}
 
+	if (opts.heading && (!opts.heading.title || !opts.heading.title.trim())) {
+		throw new Error('"o-overlay error": To have a heading, a non-empty title needs to be set');
+	}
+
 	// Overlays that don't point at anything should be modal by default
 	if (!opts.arrow && typeof opts.modal === 'undefined') {
 		opts.modal = true;

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -116,7 +116,11 @@ const Overlay = function(id, opts) {
 		this.opts.trigger.addEventListener('click', triggerClickHandler.bind(this.opts.trigger, id), false);
 		this.context = this.opts.arrow ? oLayers.getLayerContext(this.opts.arrow.target) : oLayers.getLayerContext(this.opts.trigger);
 	} else {
-		this.context = this.opts.arrow ? oLayers.getLayerContext(this.opts.arrow.target) : document.body;
+		if (this.opts.parentNode) {
+			this.context = document.querySelector(this.opts.parentNode);
+		} else {
+			this.context = this.opts.arrow ? oLayers.getLayerContext(this.opts.arrow.target) : document.body;
+		}
 	}
 
 	this.delegates = {
@@ -244,8 +248,12 @@ Overlay.prototype.show = function() {
 	this.delegates.context.root(this.context);
 
 	this.closeHandler = this.close.bind(this);
-	this.resizeListenerHandler = this.resizeListener.bind(this);
-	this.delegates.doc.on('oViewport.resize', 'body', this.resizeListenerHandler);
+
+	if (!this.opts.nested) {
+		this.resizeListenerHandler = this.resizeListener.bind(this);
+		this.delegates.doc.on('oViewport.resize', 'body', this.resizeListenerHandler);
+	}
+
 	this.closeOnNewLayerHandler = this.closeOnNewLayer.bind(this);
 	this.delegates.context.on('oLayers.new', this.closeOnNewLayerHandler);
 
@@ -284,7 +292,7 @@ Overlay.prototype.show = function() {
 		}
 		overlay.width = overlay.getWidth();
 		overlay.height = overlay.getHeight();
-		overlay.respondToWindow(viewport.getSize());
+		if (!overlay.opts.nested) { overlay.respondToWindow(viewport.getSize()); }
 		overlay.visible = true;
 		overlay.wrapper.focus();
 		overlay.broadcast('ready');


### PR DESCRIPTION
This commit adds new config options:

- Title.visuallyHideTitle: Boolean. Prevent the overlay title from being added to the overlay (except for the aria markup)
- nested: Boolean - this will remove all of the positioning and
repositioning logic. This will allow the user to handle that behaviour
themselves
- parentNode: Should be a selector for the parent element to append the
overlay to. When used with `nested: true` this option can be used to
position the overlay somewhere other than in the middle of the page or
relative to a target (the other two options currently supported)

O-overlay is due some TLC which will happen as part of the next major. The key thing with this PR is that it doesn't break any existing implementations and allows @aendrew to get on with his bootcamp in next!