### PR TITLE
✨ Adds noFocus option to prevent tabindex from being set

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ var myOverlay = new Overlay('myOverlay', {
 * `customclose`: Boolean. If you do not use the header, but want to provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
 * `parentNode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the `body` will be used.
 * `nested`: Boolean. If set to true, the resize listeners will not be set up. This boolean should be used in conjunction with the `parentNode` setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. _Default_: false.
+* `noFocus`: Boolean. If set to true, the tabindex will not be set on the wrapper element. Useful in conjunction with the `nested` and `parentNode` options. _Default_: false.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.
 

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -192,10 +192,12 @@ Overlay.prototype.render = function() {
 			const button = document.createElement('a');
 			button.className = 'o-overlay__close';
 			button.setAttribute('role', 'button');
-			button.setAttribute('tabindex', '0');
 			button.setAttribute('href', '#void');
 			button.setAttribute('aria-label', 'Close');
 			button.setAttribute('title', 'Close');
+			if (!this.opts.noFocus) {
+				button.setAttribute('tabindex', '0');
+			}
 			heading.appendChild(button);
 		}
 
@@ -215,10 +217,13 @@ Overlay.prototype.render = function() {
 		const button = document.createElement('a');
 		button.className = 'o-overlay__close';
 		button.setAttribute('role', 'button');
-		button.setAttribute('tabindex', '0');
 		button.setAttribute('href', '#void');
 		button.setAttribute('aria-label', 'Close');
 		button.setAttribute('title', 'Close');
+		if (!this.opts.noFocus) {
+			button.setAttribute('tabindex', '0');
+		}
+
 		wrapperEl.appendChild(button);
 		wrapperEl.classList.add('o-overlay--compact');
 	}
@@ -275,9 +280,10 @@ Overlay.prototype.show = function() {
 	this.context.appendChild(this.wrapper);
 
 	// Give the overlay focus
-	this.wrapper.setAttribute('tabindex', '0');
-	this.wrapper.style.outline = 0;
-
+	if (!this.opts.noFocus) {
+		this.wrapper.setAttribute('tabindex', '0');
+		this.wrapper.style.outline = 0;
+	}
 
 	// Renders content after overlay has been added so css is applied before that
 	// Thay way if an element has autofocus, the window won't scroll to the bottom


### PR DESCRIPTION
The tabindex=0 on various elements causes weird behaviours when using the `parentNode` and `nested` options, particularly when animating. 

This PR adds a `noFocus` option that disables the `tabindex` attribute setters when `true`. It defaults to `false` so is backwards compatible. 