### PR TITLE
Reduce overlay behaviour for nested overlays, allow more properties to be set via attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ var myOverlay = new Overlay('myOverlay', {
 * `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
 * `customclose`: Boolean. If you do not use the header, but want to provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
 * `parentnode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the `body` will be used.
-* `nested`: Boolean. If set to true, the resize, escape, and layer listeners will not be set up. This boolean should be used in conjunction with the `parentnode` setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. _Default_: false.
+* `nested`: Boolean. If set to true, the resize and escape key listeners will not be set up. This boolean should be used in conjunction with the `parentnode` setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. _Default_: false.
 * `nofocus`: Boolean. If set to true, the tabindex will not be set on the wrapper element. Useful in conjunction with the `nested` and `parentnode` options. _Default_: false.
+* `layer`: Boolean. If set to true, the overlay will be treated as an o-layer, firing oLayers.new and oLayers.close events when created and destroyed, and closing itself when another oLayers.new event fires. You may want to set this to false if using a `nested` overlay. _Default_: true.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ var myOverlay = new Overlay('myOverlay', {
 * `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '10'
 * `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
 * `customclose`: Boolean. If you do not use the header, but want to provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
-* `parentNode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the `body` will be used.
-* `nested`: Boolean. If set to true, the resize listeners will not be set up. This boolean should be used in conjunction with the `parentNode` setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. _Default_: false.
-* `noFocus`: Boolean. If set to true, the tabindex will not be set on the wrapper element. Useful in conjunction with the `nested` and `parentNode` options. _Default_: false.
+* `parentnode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the `body` will be used.
+* `nested`: Boolean. If set to true, the resize, escape, and layer listeners will not be set up. This boolean should be used in conjunction with the `parentnode` setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. _Default_: false.
+* `nofocus`: Boolean. If set to true, the tabindex will not be set on the wrapper element. Useful in conjunction with the `nested` and `parentnode` options. _Default_: false.
 
 The only option that must be set is either `src` or `html`. The `html` option can't be set as a `data-` attribute, and if you set both, the `html` one will override `src`.
 

--- a/demos/src/sliding-notification.js
+++ b/demos/src/sliding-notification.js
@@ -3,11 +3,11 @@ import Overlay from '../../main';
 document.addEventListener("DOMContentLoaded", function() {
 	let myOverlay = new Overlay('demo-overlay', {
 		nested: 'true',
-		parentNode: '.right-rail',
+		parentnode: '.right-rail',
 		modal: false,
 		compact: true,
 		preventclosing: false,
-		addCloseBtn: true,
+		addclosebtn: true,
 		heading: { title: "Take a survey", visuallyHideTitle: true },
 		html: `<div class='demo-overlay-content'><span class='title'>How do you rate FT.com?</span><p>Take our short survey and be in with a chance to win £250</p>
 					<button onclick="window.location.reload(true)" class="o-buttons o-buttons--standout">Take survey</button>

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -22,6 +22,14 @@ const checkOptions = function(opts) {
 		throw new Error('"o-overlay error": Compact overlays can\'t have a shaded header');
 	}
 
+	// Map old names for options
+	if (opts.parentNode) {
+		opts.parentnode = opts.parentNode;
+	}
+	if (opts.noFocus) {
+		opts.nofocus = opts.noFocus;
+	}
+
 	return opts;
 };
 
@@ -70,9 +78,9 @@ const triggerClickHandler = function(id, ev) {
  * @param {String} opts.zindex - Value of the CSS z-index property of the overlay. Default set via CSS: '10'
  * @param {Boolean} opts.preventclosing - Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
  * @param {Boolean} opts.customclose - If you do not use the heading, but want to provide a close button in your html / src (with a class of o-overlay__close), setting customclose to true will attach o-overlay's close handler function to that button.
- * @param {String} opts.parentNode - Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the body will be used.
- * @param {Boolean} opts.nested - If set to true, the resize listeners will not be set up. This boolean should be used in conjunction with the parentNode setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. Default: false.
- * @param {Boolean} opts.noFocus - If set to true, the tabindex will not be set on the wrapper element. Useful in conjunction with the nested and parentNode options. Default: false.
+ * @param {String} opts.parentnode - Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the body will be used.
+ * @param {Boolean} opts.nested - If set to true, the resize, escape, and layer listeners will not be set up. This boolean should be used in conjunction with the parentnode setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. Default: false.
+ * @param {Boolean} opts.nofocus - If set to true, the tabindex will not be set on the wrapper element. Useful in conjunction with the nested and parentnode options. Default: false.
 */
 const Overlay = function(id, opts) {
 	viewport.listenTo('resize');
@@ -99,8 +107,8 @@ const Overlay = function(id, opts) {
 		this.opts.trigger.addEventListener('click', triggerClickHandler.bind(this.opts.trigger, id), false);
 		this.context = oLayers.getLayerContext(this.opts.trigger);
 	} else {
-		if (document.querySelector(this.opts.parentNode)) {
-			this.context = document.querySelector(this.opts.parentNode);
+		if (document.querySelector(this.opts.parentnode)) {
+			this.context = document.querySelector(this.opts.parentnode);
 		} else {
 			this.context = document.body;
 		}
@@ -179,7 +187,7 @@ Overlay.prototype.render = function() {
 			button.setAttribute('href', '#void');
 			button.setAttribute('aria-label', 'Close');
 			button.setAttribute('title', 'Close');
-			if (!this.opts.noFocus) {
+			if (!this.opts.nofocus) {
 				button.setAttribute('tabindex', '0');
 			}
 			heading.appendChild(button);
@@ -204,7 +212,7 @@ Overlay.prototype.render = function() {
 		button.setAttribute('href', '#void');
 		button.setAttribute('aria-label', 'Close');
 		button.setAttribute('title', 'Close');
-		if (!this.opts.noFocus) {
+		if (!this.opts.nofocus) {
 			button.setAttribute('tabindex', '0');
 		}
 
@@ -243,9 +251,7 @@ Overlay.prototype.show = function() {
 	if (!this.opts.nested) {
 		this.resizeListenerHandler = this.resizeListener.bind(this);
 		this.delegates.doc.on('oViewport.resize', 'body', this.resizeListenerHandler);
-	}
 
-	if (!this.opts.parentNode) {
 		this.closeOnNewLayerHandler = this.closeOnNewLayer.bind(this);
 		this.delegates.context.on('oLayers.new', this.closeOnNewLayerHandler);
 
@@ -267,7 +273,7 @@ Overlay.prototype.show = function() {
 	this.context.appendChild(this.wrapper);
 
 	// Give the overlay focus
-	if (!this.opts.noFocus) {
+	if (!this.opts.nofocus) {
 		this.wrapper.setAttribute('tabindex', '0');
 		this.wrapper.style.outline = 0;
 	}

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -13,9 +13,12 @@ const checkOptions = function(opts) {
 		throw new Error('"o-overlay error": To have a heading, a non-empty title needs to be set');
 	}
 
-	// Overlays should be modal by default
+	// Overlays should be modal and layers by default
 	if (typeof opts.modal === 'undefined') {
 		opts.modal = true;
+	}
+	if (typeof opts.layer === 'undefined') {
+		opts.layer = true;
 	}
 
 	if (opts.compact && opts.heading && opts.heading.shaded) {
@@ -254,13 +257,15 @@ Overlay.prototype.show = function() {
 		this.resizeListenerHandler = this.resizeListener.bind(this);
 		this.delegates.doc.on('oViewport.resize', 'body', this.resizeListenerHandler);
 
+		this.closeOnEscapePressHandler = this.closeOnEscapePress.bind(this);
+		this.delegates.doc.on('keyup', this.closeOnEscapePressHandler);
+	}
+
+	if (this.opts.layer) {
 		this.closeOnNewLayerHandler = this.closeOnNewLayer.bind(this);
 		this.delegates.context.on('oLayers.new', this.closeOnNewLayerHandler);
 
 		this.broadcast('new', 'oLayers');
-
-		this.closeOnEscapePressHandler = this.closeOnEscapePress.bind(this);
-		this.delegates.doc.on('keyup', this.closeOnEscapePressHandler);
 	}
 
 	if (this.opts.heading || this.opts.tooltip || this.opts.customclose) {
@@ -338,7 +343,11 @@ Overlay.prototype.close = function() {
 		this.opts.trigger.setAttribute('aria-pressed', 'false');
 	}
 	this.visible = false;
-	this.broadcast('close', 'oLayers');
+
+	if (this.opts.layer) {
+		this.broadcast('close', 'oLayers');
+	}
+
 	return false;
 };
 

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -24,9 +24,11 @@ const checkOptions = function(opts) {
 
 	// Map old names for options
 	if (opts.parentNode) {
+		console.warn('Please change the instantation of o-overlay to use the `parentnode` option instead of `parentNode`. `parentNode` will be removed in a future major version.');
 		opts.parentnode = opts.parentNode;
 	}
 	if (opts.noFocus) {
+		console.warn('Please change the instantation of o-overlay to use the `nofocus` option instead of `noFocus`. `noFocus` will be removed in a future major version.');
 		opts.nofocus = opts.noFocus;
 	}
 

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -245,8 +245,15 @@ Overlay.prototype.show = function() {
 		this.delegates.doc.on('oViewport.resize', 'body', this.resizeListenerHandler);
 	}
 
-	this.closeOnNewLayerHandler = this.closeOnNewLayer.bind(this);
-	this.delegates.context.on('oLayers.new', this.closeOnNewLayerHandler);
+	if (!this.opts.parentNode) {
+		this.closeOnNewLayerHandler = this.closeOnNewLayer.bind(this);
+		this.delegates.context.on('oLayers.new', this.closeOnNewLayerHandler);
+
+		this.broadcast('new', 'oLayers');
+
+		this.closeOnEscapePressHandler = this.closeOnEscapePress.bind(this);
+		this.delegates.doc.on('keyup', this.closeOnEscapePressHandler);
+	}
 
 	if (this.opts.heading || this.opts.tooltip || this.opts.customclose) {
 		this.delegates.wrap.on('click', '.o-overlay__close', this.closeHandler);
@@ -257,10 +264,6 @@ Overlay.prototype.show = function() {
 	this.delegates.doc.on('click', 'body', this.closeOnExternalClickHandler);
 	this.delegates.doc.on('touchend', 'body', this.closeOnExternalClickHandler);
 
-	this.closeOnEscapePressHandler = this.closeOnEscapePress.bind(this);
-	this.delegates.doc.on('keyup', this.closeOnEscapePressHandler);
-
-	this.broadcast('new', 'oLayers');
 	this.context.appendChild(this.wrapper);
 
 	// Give the overlay focus

--- a/test/specs/o-overlay.test.js
+++ b/test/specs/o-overlay.test.js
@@ -88,12 +88,12 @@ describe("Overlay", () => {
 			proclaim.strictEqual(oLayers.getLayerContext(document.getElementById('testTrigger')), testOverlay.context);
 		});
 
-		it("Sets the context to the parentNode if it's been set but the trigger hasn't", () => {
-			const testOverlay = new Overlay('myID', {html: 'hello', parentNode: '#element'});
+		it("Sets the context to the parentnode if it's been set but the trigger hasn't", () => {
+			const testOverlay = new Overlay('myID', {html: 'hello', parentnode: '#element'});
 			proclaim.strictEqual(document.querySelector('#element'), testOverlay.context);
 		});
 
-		it("Sets the context to the document body if there isn't a trigger or parentNode", () => {
+		it("Sets the context to the document body if there isn't a trigger or parentnode", () => {
 			const testOverlay = new Overlay('myID', {html: 'hello'});
 			proclaim.strictEqual(document.body, testOverlay.context);
 		});

--- a/test/specs/smoke.test.js
+++ b/test/specs/smoke.test.js
@@ -195,13 +195,80 @@ describe("smoke-tests (./overlay.js)", function() {
 			expect(Overlay.prototype.close.callCount).to.be(0);
 
 			o.fireCustomEvent(document.body, 'oLayers.new', {el: 'something'});
-			expect(Overlay.prototype.close.callCount).to.be(0);
+			expect(Overlay.prototype.close.callCount).to.be(1);
 
 			o.fireEvent(document.querySelector('.o-overlay__close'), 'click');
+			expect(Overlay.prototype.close.callCount).to.be(2);
+
+			Overlay.prototype.close = realCloseFunction;
+			currentOverlay.close();
+		});
+
+		it('should act as a layer by default', () => {
+			let newLayers = 0;
+			let closedLayers = 0;
+			document.body.addEventListener('oLayers.new', () => {
+				newLayers++;
+			});
+			document.body.addEventListener('oLayers.close', () => {
+				closedLayers++;
+			});
+
+			const realCloseFunction = Overlay.prototype.close;
+			const stubbedCloseFunction = sinon.stub();
+			Overlay.prototype.close = stubbedCloseFunction;
+
+			const trigger = document.querySelector('.o-overlay-trigger');
+			let overlays = Overlay.init();
+			let currentOverlay = overlays[0];
+
+			o.fireEvent(trigger, 'click');
+
+			expect(newLayers).to.be(1);
+			expect(closedLayers).to.be(0);
+
+			o.fireCustomEvent(document.body, 'oLayers.new', {el: 'something'});
 			expect(Overlay.prototype.close.callCount).to.be(1);
 
 			Overlay.prototype.close = realCloseFunction;
 			currentOverlay.close();
+
+			expect(newLayers).to.be(2);
+			expect(closedLayers).to.be(1);
+		});
+
+		it('should support having layer functionality disabled', () => {
+			let newLayers = 0;
+			let closedLayers = 0;
+			document.body.addEventListener('oLayers.new', () => {
+				newLayers++;
+			});
+			document.body.addEventListener('oLayers.close', () => {
+				closedLayers++;
+			});
+
+			const realCloseFunction = Overlay.prototype.close;
+			const stubbedCloseFunction = sinon.stub();
+			Overlay.prototype.close = stubbedCloseFunction;
+
+			const trigger = document.querySelector('.o-overlay-trigger');
+			trigger.setAttribute('data-o-overlay-layer', 'false');
+			let overlays = Overlay.init();
+			let currentOverlay = overlays[0];
+
+			o.fireEvent(trigger, 'click');
+
+			expect(newLayers).to.be(0);
+			expect(closedLayers).to.be(0);
+
+			o.fireCustomEvent(document.body, 'oLayers.new', {el: 'something'});
+			expect(Overlay.prototype.close.callCount).to.be(0);
+
+			Overlay.prototype.close = realCloseFunction;
+			currentOverlay.close();
+
+			expect(newLayers).to.be(1);
+			expect(closedLayers).to.be(0);
 		});
 
 		it('should remove all traces on close', function() {

--- a/test/specs/smoke.test.js
+++ b/test/specs/smoke.test.js
@@ -37,11 +37,11 @@ describe("smoke-tests (./overlay.js)", function() {
 
 		afterEach(() => {
 			const testEl = document.querySelector('.test-overlay');
-			if (testEl) testEl.parentNode.removeChild(testEl);
+			testEl.parentNode.removeChild(testEl);
 			const triggerEl = document.querySelector('.o-overlay-trigger');
-			if (triggerEl) triggerEl.parentNode.removeChild(triggerEl);
+			triggerEl.parentNode.removeChild(triggerEl);
 			const containerEl = document.querySelector('.js-container');
-			if (containerEl) containerEl.parentNode.removeChild(containerEl);
+			containerEl.parentNode.removeChild(containerEl);
 		});
 
 		it('should open with correct content when trigger is clicked', done => {

--- a/test/specs/smoke.test.js
+++ b/test/specs/smoke.test.js
@@ -181,18 +181,23 @@ describe("smoke-tests (./overlay.js)", function() {
 
 			const trigger = document.querySelector('.o-overlay-trigger');
 			trigger.setAttribute('data-o-overlay-modal', 'false');
-			trigger.setAttribute('data-o-overlay-parentNode', '.js-container');
+			trigger.setAttribute('data-o-overlay-parentnode', '.js-container');
+			trigger.setAttribute('data-o-overlay-nested', 'true');
 
 			const overlays = Overlay.init();
 			const currentOverlay = overlays[0];
 
 			o.fireEvent(trigger, 'click');
-			o.fireEvent(document.querySelector('.o-overlay__close'), 'click');
+
 			o.fireEvent(document.body, 'keyup', {
 				keyCode: 27
 			});
-			o.fireCustomEvent(document.body, 'oLayers.new', {el: 'something'});
+			expect(Overlay.prototype.close.callCount).to.be(0);
 
+			o.fireCustomEvent(document.body, 'oLayers.new', {el: 'something'});
+			expect(Overlay.prototype.close.callCount).to.be(0);
+
+			o.fireEvent(document.querySelector('.o-overlay__close'), 'click');
 			expect(Overlay.prototype.close.callCount).to.be(1);
 
 			Overlay.prototype.close = realCloseFunction;


### PR DESCRIPTION
Overlays support nested mode within a page, but had some behaviours which only really made sense when they're not nested:
 - Nested overlays closed when the escape key was pressed
 - Nested overlays closed when a new `layer` was opened
 - Nested overlays sent a new `layer` event on creation, closing other layers
I think this is unintended behaviour, preventing the use of multiple nested overlays... this PR treats those behaviours as bugs and prevents them.  Thoughts?

Creation of a testcase also highlighted that some of the more recent properties (`parentNode` and `noFocus`) couldn't be set from attributes, as they're camelCase but get lowercased when plucking from the attribute.  I've changed them all to lowercase to match the older properties but converted the old option names so this doesn't need to be a major version bump.