### PR TITLE
increase overlay z-index to be greater than the ft.com sticky header

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var myOverlay = new Overlay('myOverlay', {
 * `src`: String. Either a _url_ from which HTML to populate the overlay can be loaded, or a querySelector string identifying an element from which the textContent should be extracted.
 * `html`: String or HTMLElement.  Raw HTML (cannot be set declaratively)
 * `trigger`: String or HTMLElement. querySelector expression or HTMLElement. When there's a trigger set, a click event handler will be added to it that will open or close the overlay accordingly. (cannot be set declaratively)
-* `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '10'
+* `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '150'
 * `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
 * `customclose`: Boolean. If you do not use the header, but want to provide a close button in your html / src (with a class of `o-overlay__close`), setting customclose to true will attach o-overlay's close handler function to that button.
 * `parentnode`: String. Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the `body` will be used.

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -80,7 +80,7 @@ const triggerClickHandler = function(id, ev) {
  * @param {String} opts.src - Either a url from which HTML to populate the overlay can be loaded, or a querySelector string identifying an element from which the textContent should be extracted.
  * @param {String} opts.html - String or HTMLElement. Raw HTML (cannot be set declaratively)
  * @param {String} opts.trigger - querySelector expression or HTMLElement. When there's a trigger set, a click event handler will be added to it that will open or close the overlay accordingly. (cannot be set declaratively)
- * @param {String} opts.zindex - Value of the CSS z-index property of the overlay. Default set via CSS: '10'
+ * @param {String} opts.zindex - Value of the CSS z-index property of the overlay. Default set via CSS: '150'
  * @param {Boolean} opts.preventclosing - Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.
  * @param {Boolean} opts.customclose - If you do not use the heading, but want to provide a close button in your html / src (with a class of o-overlay__close), setting customclose to true will attach o-overlay's close handler function to that button.
  * @param {String} opts.parentnode - Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the body will be used.

--- a/src/scss/overlay.scss
+++ b/src/scss/overlay.scss
@@ -6,7 +6,7 @@
 /// Base overlay style
 @mixin oOverlay {
 	position: fixed;
-	z-index: 10;
+	z-index: 150;
 	box-sizing: border-box;
 	opacity: 1;
 	transition: opacity 0.3s ease-in-out;
@@ -27,7 +27,7 @@
 	width: 100%;
 	top: 0;
 	left: 0;
-	z-index: 10;
+	z-index: 150;
 	opacity: 1;
 	transition: opacity 0.3s ease-in-out;
 }


### PR DESCRIPTION
So I think that this is all that's required to increase the z-index of o-overlays. It's almost worryingly simple so if you think I've missed something, please shout 😄 

In any case, I was thinking that this should be a minor release as it changes the way the element displays - guidance on minor v patch welcome 🙇 