### PR TITLE
Adds a full screen and class option to modals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ var myOverlay = new Overlay('myOverlay', {
 	* `.visuallyHideTitle`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling) _Default_: false.
 	* `.shaded`: Boolean. Whether to shade the background of the header
 * `modal`: Boolean. Whether the overlay should have modal behaviour or not. Setting this as true will add a translucent shadow between the page and the overlay
+* `fullscreen`: Boolean. If set to true, the overlay will display full screen. This overlay disables scroll on the underlying document and is dismissible with the back button.
 * `compact`: Boolean. If true, the `.o-overlay--compact` class will be added to the overlay that reduces heading font-size and paddings in the content.
 * `src`: String. Either a _url_ from which HTML to populate the overlay can be loaded, or a querySelector string identifying an element from which the textContent should be extracted.
 * `html`: String or HTMLElement.  Raw HTML (cannot be set declaratively)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ var myOverlay = new Overlay('myOverlay', {
 * `compact`: Boolean. If true, the `.o-overlay--compact` class will be added to the overlay that reduces heading font-size and paddings in the content.
 * `src`: String. Either a _url_ from which HTML to populate the overlay can be loaded, or a querySelector string identifying an element from which the textContent should be extracted.
 * `html`: String or HTMLElement.  Raw HTML (cannot be set declaratively)
+* `data-o-overlay-class`: String. The custom classes to apply to to the overlay e.g. `o-overlay--my-modifier`.
 * `trigger`: String or HTMLElement. querySelector expression or HTMLElement. When there's a trigger set, a click event handler will be added to it that will open or close the overlay accordingly. (cannot be set declaratively)
 * `zindex`: String. Value of the CSS z-index property of the overlay. _Default set via CSS_: '10'
 * `preventclosing`: Boolean. Prevents closure of overlay via standard x button or escape key. For use when you are directing the user to somewhere else. Only valid with modal set to true.

--- a/demos/src/modal-fullscreen.mustache
+++ b/demos/src/modal-fullscreen.mustache
@@ -1,0 +1,6 @@
+<button class="o-overlay-trigger o-buttons  o-buttons--big" data-o-overlay-id="overlay" data-o-overlay-src="#overlay" data-o-overlay-heading-title="Welcome to this fullscreen overlay" data-o-overlay-heading-shaded="false" data-o-overlay-fullscreen="true" data-o-overlay-modal="true" data-o-overlay-preventclosing="false" data-o-overlay-zIndex="20" aria-pressed="false" aria-haspopup="true">Launch fullscreen overlay</button>
+
+<script type="text/template" id="overlay">
+	<p>This fullscreen overlay may be dismissed with the back button or with the cross icon.</p>
+	<button onclick="window.location.reload(true)" class="o-buttons">OK</button>
+</script>

--- a/demos/src/modal.mustache
+++ b/demos/src/modal.mustache
@@ -1,4 +1,4 @@
-<button class="o-overlay-trigger o-buttons  o-buttons--big" data-o-overlay-id="overlay" data-o-overlay-src="#overlay" data-o-overlay-heading-title="We're not having trouble updating" data-o-overlay-heading-shaded="false" data-o-overlay-fullscreen="true" data-o-overlay-modal="true" data-o-overlay-preventclosing="false" data-o-overlay-zIndex="20" aria-pressed="false" aria-haspopup="true">Launch overlay</button>
+<button class="o-overlay-trigger o-buttons  o-buttons--big" data-o-overlay-id="overlay" data-o-overlay-src="#overlay" data-o-overlay-heading-title="We're not having trouble updating" data-o-overlay-heading-shaded="false" data-o-overlay-modal="true" data-o-overlay-preventclosing="false" data-o-overlay-zIndex="20" aria-pressed="false" aria-haspopup="true">Launch overlay</button>
 
 <script type="text/template" id="overlay">
 	<div class='demo-overlay'>

--- a/demos/src/modal.mustache
+++ b/demos/src/modal.mustache
@@ -1,4 +1,4 @@
-<button class="o-overlay-trigger o-buttons  o-buttons--big" data-o-overlay-id="overlay" data-o-overlay-src="#overlay" data-o-overlay-heading-title="We're not having trouble updating" data-o-overlay-heading-shaded="false" data-o-overlay-modal="true" data-o-overlay-preventclosing="false" data-o-overlay-zIndex="20" aria-pressed="false" aria-haspopup="true">Launch overlay</button>
+<button class="o-overlay-trigger o-buttons  o-buttons--big" data-o-overlay-id="overlay" data-o-overlay-src="#overlay" data-o-overlay-heading-title="We're not having trouble updating" data-o-overlay-heading-shaded="false" data-o-overlay-fullscreen="true" data-o-overlay-modal="true" data-o-overlay-preventclosing="false" data-o-overlay-zIndex="20" aria-pressed="false" aria-haspopup="true">Launch overlay</button>
 
 <script type="text/template" id="overlay">
 	<div class='demo-overlay'>

--- a/main.scss
+++ b/main.scss
@@ -82,6 +82,9 @@
 		@include oOverlayFullscreen($fill: 'height');
 	}
 
+	.#{$classname}--full-screen {
+		@include oOverlayFullscreen();
+	}
 }
 
 @if ($o-overlay-is-silent == false) {

--- a/main.scss
+++ b/main.scss
@@ -72,10 +72,12 @@
 		}
 	}
 
+	.#{$classname}--full-screen,
 	.#{$classname}--full-width {
 		@include oOverlayFullscreen($fill: 'width');
 	}
 
+	.#{$classname}--full-screen,
 	.#{$classname}--full-height {
 		@include oOverlayFullscreen($fill: 'height');
 	}

--- a/origami.json
+++ b/origami.json
@@ -36,6 +36,12 @@
 			"template": "/demos/src/modal.mustache"
 		},
 		{
+			"name": "modal-fullscreen",
+			"title": "Modal fullscreen overlay",
+			"description": "Fullscreen modal. The user can dismiss the overlay with the close button or back button.",
+			"template": "/demos/src/modal-fullscreen.mustache"
+		},
+		{
 			"name": "modal-prevent-closure",
 			"title": "Modal without close button",
 			"description": "Modal without a dismiss button in the top right. This should be used where the user has to make a choice or confirm they've seen something.",

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -131,7 +131,7 @@ const Overlay = function(id, opts) {
 
 Overlay.prototype.open = function() {
 
-	if (window.history.pushState) {
+	if (window.history.pushState && this.opts.fullscreen) {
 		this.popstateHandler = this.close.bind(this);
 		window.addEventListener("popstate", this.popstateHandler);
 		window.history.pushState({ 'overlay': 'fullscreen' }, window.location.href);

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -131,7 +131,7 @@ const Overlay = function(id, opts) {
 
 Overlay.prototype.open = function() {
 
-	if (window.history.pushState && this.opts.fullscreen) {
+	if (window.history.pushState) {
 		this.popstateHandler = this.close.bind(this);
 		window.addEventListener("popstate", this.popstateHandler);
 		window.history.pushState({ 'overlay': 'fullscreen' }, window.location.href);
@@ -336,7 +336,10 @@ Overlay.prototype.close = function() {
 	this.delegates.context.destroy();
 
 	window.removeEventListener("popstate", this.popstateHandler);
-	if (window.history.pushState && window.history.state.overlay == 'fullscreen') {
+	if (window.history.pushState &&
+		window.history.state &&
+		window.history.state.overlay == 'fullscreen'
+	) {
 		window.history.back();
 	}
 

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -182,10 +182,12 @@ Overlay.prototype.render = function() {
 	wrapperEl.classList.add('o-overlay--' + this.id.replace(' ', '-'));
 
 	// Add custom classes to the newly created overlay wrapper.
-	try {
-		wrapperEl.classList.add(...this.opts.class.split(' '));
-	} catch (error) {
-		console.warn(`Could not add the classes: ${this.opts.class}`);
+	if (this.opts.class) {
+		try {
+			wrapperEl.classList.add(...this.opts.class.split(' '));
+		} catch (error) {
+			console.warn(`Could not add the classes: ${this.opts.class}`);
+		}
 	}
 
 	if (this.opts.fullscreen) {

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -130,6 +130,13 @@ const Overlay = function(id, opts) {
 };
 
 Overlay.prototype.open = function() {
+
+	if (window.history.pushState && this.opts.fullscreen) {
+		this.popstateHandler = this.close.bind(this);
+		window.addEventListener("popstate", this.popstateHandler);
+		window.history.pushState({ 'overlay': 'fullscreen' }, window.location.href);
+	}
+
 	if (this.opts.trigger) {
 		this.opts.trigger.setAttribute('aria-pressed', 'true');
 	}
@@ -168,6 +175,11 @@ Overlay.prototype.render = function() {
 	const wrapperEl = document.createElement('div');
 	wrapperEl.className = 'o-overlay';
 	wrapperEl.classList.add('o-overlay--' + this.id.replace(' ', '-'));
+
+	if (this.opts.fullscreen) {
+		wrapperEl.classList.add('o-overlay--full-screen');
+	}
+
 	wrapperEl.setAttribute('role', 'dialog');
 	if (this.opts.zindex) {
 		wrapperEl.style.zIndex = this.opts.zindex;
@@ -322,6 +334,11 @@ Overlay.prototype.close = function() {
 	this.delegates.doc.destroy();
 	this.delegates.wrap.destroy();
 	this.delegates.context.destroy();
+
+	window.removeEventListener("popstate", this.popstateHandler);
+	if (window.history.pushState && window.history.state.overlay == 'fullscreen') {
+		window.history.back();
+	}
 
 	viewport.stopListeningTo('resize');
 

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -338,7 +338,7 @@ Overlay.prototype.close = function() {
 	window.removeEventListener("popstate", this.popstateHandler);
 	if (window.history.pushState &&
 		window.history.state &&
-		window.history.state.overlay == 'fullscreen'
+		window.history.state.overlay === 'fullscreen'
 	) {
 		window.history.back();
 	}

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -86,6 +86,7 @@ const triggerClickHandler = function(id, ev) {
  * @param {String} opts.parentnode - Should be a query selector for a DOM element. If set, the overlay will be appended as a child of this rather than the document body or target. If multiple nodes are matched, it will use the first. If nothing matches this selector, the body will be used.
  * @param {Boolean} opts.nested - If set to true, the resize, escape, and layer listeners will not be set up. This boolean should be used in conjunction with the parentnode setting to allow an overlay to be positioned within a DOM element rather than overlaid on top of everything. Default: false.
  * @param {Boolean} opts.nofocus - If set to true, the tabindex will not be set on the wrapper element. Useful in conjunction with the nested and parentnode options. Default: false.
+ * @param {Boolean} opts.fullscreen - If set to true, the overlay will display full screen. This overlay disables scroll on the underlying document and is dismissible with the back button.
 */
 const Overlay = function(id, opts) {
 	viewport.listenTo('resize');
@@ -131,8 +132,12 @@ const Overlay = function(id, opts) {
 
 Overlay.prototype.open = function() {
 
+	// A full screen overlay can look like a new page so add to history.
+	// The browser back button can then be used to close a full-screen overlay.
 	if (window.history.pushState && this.opts.fullscreen) {
 		this.popstateHandler = this.close.bind(this);
+		this.originalOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
 		window.addEventListener("popstate", this.popstateHandler);
 		window.history.pushState({ 'overlay': 'fullscreen' }, window.location.href);
 	}
@@ -335,7 +340,13 @@ Overlay.prototype.close = function() {
 	this.delegates.wrap.destroy();
 	this.delegates.context.destroy();
 
-	window.removeEventListener("popstate", this.popstateHandler);
+	// Remove fullscreen popstate handler and re-enable document scroll.
+	if (this.opts.fullscreen) {
+		window.removeEventListener("popstate", this.popstateHandler);
+		document.body.style.overflow = this.originalOverflow;
+	}
+	// Remove state from history if fullscreen state is still in history.
+	// E.g.The close button was clicked directly rather than the browser back button.
 	if (window.history.pushState &&
 		window.history.state &&
 		window.history.state.overlay === 'fullscreen'

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -181,6 +181,13 @@ Overlay.prototype.render = function() {
 	wrapperEl.className = 'o-overlay';
 	wrapperEl.classList.add('o-overlay--' + this.id.replace(' ', '-'));
 
+	// Add custom classes to the newly created overlay wrapper.
+	try {
+		wrapperEl.classList.add(...this.opts.class.split(' '));
+	} catch (error) {
+		console.warn(`Could not add the classes: ${this.opts.class}`);
+	}
+
 	if (this.opts.fullscreen) {
 		wrapperEl.classList.add('o-overlay--full-screen');
 	}

--- a/src/scss/_fullscreen.scss
+++ b/src/scss/_fullscreen.scss
@@ -5,8 +5,8 @@
 
 /// Add to the overlay for a for it to stretch to full width or full height
 ///
-/// @param {String} fill - 'width' or 'height'
-@mixin oOverlayFullscreen($fill) {
+/// @param {String|null} fill - 'width' or 'height'
+@mixin oOverlayFullscreen($fill: null) {
 	@if ($fill == 'width') {
 		padding-left: 0;
 		padding-right: 0;
@@ -15,5 +15,7 @@
 		padding-top: 0;
 		padding-bottom: 0;
 		height: 100%;
+	} @else if ($fill == null) {
+		border: 0;
 	}
 }

--- a/test/specs/o-overlay.test.js
+++ b/test/specs/o-overlay.test.js
@@ -147,6 +147,19 @@ describe("Overlay", () => {
 				done();
 			}, 10);
 		});
+
+		it("Adds custom classes to the overlay.", (done) => {
+			const testOverlay = new Overlay('myID', {
+				html: 'hello',
+				class: 'myCustomClass mySecondCustomClass'
+			});
+			testOverlay.open();
+			setTimeout(() => {
+				proclaim.isTrue(document.querySelector('.o-overlay').classList.contains("myCustomClass"));
+				proclaim.isTrue(document.querySelector('.o-overlay').classList.contains("mySecondCustomClass"));
+				done();
+			}, 10);
+		});
 	});
 });
 

--- a/test/specs/o-overlay.test.js
+++ b/test/specs/o-overlay.test.js
@@ -101,6 +101,52 @@ describe("Overlay", () => {
 			const testOverlay = new Overlay('myID', {html: 'hello'});
 			proclaim.strictEqual(document.body, testOverlay.context);
 		});
+
+		it("Does not add state to history when not in full screen mode.", () => {
+			const testOverlay = new Overlay('myID', { html: 'hello', fullscreen: false });
+			testOverlay.open();
+			proclaim.isNull(history.state);
+		});
+
+		it("Does not disable document scrolling when not in full screen mode.", (done) => {
+			const testOverlay = new Overlay('myID', { html: 'hello' });
+			testOverlay.open();
+			setTimeout(() => {
+				proclaim.equal('', document.body.style.overflow);
+				done();
+			}, 10);
+		});
+
+		it("Adds state to history when opened in full screen mode if supported.", () => {
+			const testOverlay = new Overlay('myID', {html: 'hello', fullscreen: true});
+			proclaim.isNull(history.state);
+			testOverlay.open();
+			if (window.history.pushState) {
+				proclaim.equal(history.state.overlay, 'fullscreen');
+			}
+		});
+
+		it("Removes state from history when opened in full screen mode if supported.", () => {
+			const testOverlay = new Overlay('myID', {html: 'hello', fullscreen: true});
+			sinon.spy(window.history, "back");
+			testOverlay.open();
+			testOverlay.close();
+			if (window.history.pushState) {
+				proclaim.isTrue(window.history.back.called);
+
+			}
+			window.history.back.restore();
+		});
+
+		it("Disables document scrolling with an open full screen overlay.", (done) => {
+			const testOverlay = new Overlay('myID', {html: 'hello'});
+			testOverlay.open();
+			setTimeout(() => {
+				proclaim.equal('hidden', document.body.style.overflow);
+				testOverlay.close();
+				done();
+			}, 10);
+		});
 	});
 });
 


### PR DESCRIPTION
Full screen option:
- Full screen modals are easy to confuse for pages: Back button exits the modal in supported browsers.
- Disables scrolling on the document behind the modal.
- Removes the modal border when full screen.

Class option:
- Enables a client to provide class names to add to the generated overlay wrapper. This allows a client to easily provide custom CSS to an individual instance of an overlay.

This is to support a mobile share interface: https://github.com/Financial-Times/o-overlay/issues/143