### PR TITLE
Update `realign` so its arguments are optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ $o-overlay-is-silent: false;
 
 * `open`: Display the overlay.  Content is loaded every time the overlay is opened.
 * `close`: Close (hide) the overlay.
+* `realign`: Realign the overlay. Useful when overlay content changes whilst the overlay is open.
 
 ## Events
 

--- a/origami.json
+++ b/origami.json
@@ -22,10 +22,10 @@
 	"ci": {
 		"circle": "https://circleci.com/api/v1/project/Financial-Times/o-overlay"
 	},
-	"options": {
+	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"bodyClasses": "o-hoverable-on",
+		"documentClasses": "o-hoverable-on",
 		"dependencies": [
 			"o-fonts@^3.0.0",
 			"o-buttons@^5.0.0",

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -282,6 +282,7 @@ Overlay.prototype.show = function() {
 
 	this.closeHandler = this.close.bind(this);
 
+	// If the overlay is nested within a DOM element don't attach the viewport resize listeners.
 	if (!this.opts.nested) {
 		this.resizeListenerHandler = this.resizeListener.bind(this);
 		this.delegates.doc.on('oViewport.resize', 'body', this.resizeListenerHandler);
@@ -317,34 +318,33 @@ Overlay.prototype.show = function() {
 	// Renders content after overlay has been added so css is applied before that
 	// Thay way if an element has autofocus, the window won't scroll to the bottom
 	// in Safari as the overlay is already in position
-	const overlay = this;
 	window.requestAnimationFrame(function() {
-		if (!overlay.content.innerHTML) {
-			// overlay.respondToWindow(viewport.getSize());
-			if (typeof overlay.opts.html === 'string') {
-				overlay.content.innerHTML = overlay.opts.html;
+		if (!this.content.innerHTML) {
+			if (typeof this.opts.html === 'string') {
+				this.content.innerHTML = this.opts.html;
 			} else {
-				overlay.content.appendChild(overlay.opts.html);
+				this.content.appendChild(this.opts.html);
 			}
 		}
-		overlay.width = overlay.getWidth();
-		overlay.height = overlay.getHeight();
 
-		// If the overlay is nested within a DOM element don't attach the viewport resize listeners
-		if (!overlay.opts.nested) {
-			overlay.respondToWindow(viewport.getSize());
+		this.width = this.getWidth();
+		this.height = this.getHeight();
+
+		// If the overlay is nested within a DOM element don't resize according to the viewport.
+		if (!this.opts.nested) {
+			this.realign();
 		}
-		overlay.visible = true;
-		overlay.wrapper.focus();
-		overlay.broadcast('ready');
+		this.visible = true;
+		this.wrapper.focus();
+		this.broadcast('ready');
 
 		// Add o-tracking integration
-		overlay.broadcast('event', 'oTracking', {
+		this.broadcast('event', 'oTracking', {
 			category: 'overlay',
 			action: 'show',
-			overlay_id: overlay.id
+			overlay_id: this.id
 		});
-	});
+	}.bind(this));
 };
 
 Overlay.prototype.close = function() {
@@ -440,8 +440,40 @@ Overlay.prototype.broadcast = function(eventType, namespace, detail) {
 };
 
 Overlay.prototype.realign = function(dimension, size) {
+	// Realign both height and width according to the window by default.
+	if (!dimension && !size) {
+		this._align('width', viewport.getSize().width);
+		this._align('height', viewport.getSize().height);
+		return;
+	}
+
+	// For a given dimension realign according to the viewport by default.
+	if (dimension && !size) {
+		this._align(dimension, viewport.getSize()['dimension']);
+		return;
+	}
+
+	this._align(dimension, size);
+};
+
+Overlay.prototype._align = function (dimension, size) {
+
+	if (dimension != 'width' && dimension != 'height') {
+		throw new Error(`Can not realign the overlay for the dimension "${dimension}". "height" or "width" expected.`);
+	}
+
+	if (isNaN(size)) {
+		throw new Error(`Can not realign the overlay for the size ${size}. A number is expected.`);
+	}
+
 	const edge = dimension === 'width' ? 'left' : 'top';
 
+	// Update overlay size for realignment calculation.
+	// We may be realigning because the content within the overlay has changed.
+	this.width = this.getWidth();
+	this.height = this.getHeight();
+
+	// E.g. viewport dimension <= overlay dimension
 	if (size <= this[dimension]) {
 		this.wrapper.classList.add('o-overlay--full-' + dimension);
 		this.wrapper.style[edge] = '0';
@@ -459,7 +491,7 @@ Overlay.prototype.realign = function(dimension, size) {
 			this.content.style.height = null;
 		}
 		this.wrapper.classList.remove('o-overlay--full-' + dimension);
-		this.wrapper.style['margin' + utils.capitalise(edge)] = -(this.wrapper['offset' + utils.capitalise(dimension)]/2) + 'px';
+		this.wrapper.style['margin' + utils.capitalise(edge)] = -(this.wrapper['offset' + utils.capitalise(dimension)] / 2) + 'px';
 
 		// Set alignment in JavaScript (not via CSS) after all other styles have been applied
 		// so that browsers compute it properly. If it's applied earlier, when the negative
@@ -467,11 +499,10 @@ Overlay.prototype.realign = function(dimension, size) {
 		// margin would be incorrect
 		this.wrapper.style[edge] = '50%';
 	}
-};
+}
 
 Overlay.prototype.respondToWindow = function(size) {
-	this.realign('width', size.width);
-	this.realign('height', size.height);
+	this.realign();
 };
 
 Overlay.prototype.fills = function(dimension) {

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -418,7 +418,7 @@ Overlay.prototype.closeOnNewLayer = function(ev) {
 
 Overlay.prototype.resizeListener = function(ev) {
 	if (!this.wrapper.contains(ev.target)) {
-		this.respondToWindow(ev.detail.viewport);
+		this.respondToWindow();
 	}
 };
 
@@ -458,7 +458,7 @@ Overlay.prototype.realign = function(dimension, size) {
 
 Overlay.prototype._align = function (dimension, size) {
 
-	if (dimension != 'width' && dimension != 'height') {
+	if (dimension !== 'width' && dimension !== 'height') {
 		throw new Error(`Can not realign the overlay for the dimension "${dimension}". "height" or "width" expected.`);
 	}
 
@@ -499,9 +499,9 @@ Overlay.prototype._align = function (dimension, size) {
 		// margin would be incorrect
 		this.wrapper.style[edge] = '50%';
 	}
-}
+};
 
-Overlay.prototype.respondToWindow = function(size) {
+Overlay.prototype.respondToWindow = function() {
 	this.realign();
 };
 

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -133,8 +133,8 @@ const Overlay = function(id, opts) {
 Overlay.prototype.open = function() {
 	// Prevent page scroll for open modals or fullscreen overlays.
 	if (this.opts.modal || this.opts.fullscreen) {
-		this.originalOverflow = document.body.style.overflow;
-		document.body.style.overflow = 'hidden';
+		this.originalOverflow = document.documentElement.style.overflow;
+		document.documentElement.style.overflow = 'hidden';
 	}
 
 	// A full screen overlay can look like a new page so add to history.
@@ -354,7 +354,7 @@ Overlay.prototype.close = function() {
 
 	// Restore document scroll when modals or fullscreen overlays are closed.
 	if (this.opts.modal || this.opts.fullscreen) {
-		document.body.style.overflow = this.originalOverflow;
+		document.documentElement.style.overflow = this.originalOverflow;
 	}
 
 	// Remove fullscreen popstate handler and re-enable document scroll.

--- a/test/specs/o-overlay.test.js
+++ b/test/specs/o-overlay.test.js
@@ -8,18 +8,18 @@ import Overlay from './../../main';
 
 describe("Overlay", () => {
 
+	beforeEach(() => {
+		fixtures.htmlCode();
+	});
+
+	afterEach(() => {
+		Object.values(Overlay.getOverlays()).forEach(overlay => {
+			overlay.destroy();
+		});
+		fixtures.reset();
+	});
+
 	describe("Constructor", () => {
-		beforeEach(() => {
-			fixtures.htmlCode();
-		});
-
-		afterEach(() => {
-			Object.values(Overlay.getOverlays()).forEach(overlay => {
-				overlay.destroy();
-			});
-			fixtures.reset();
-		});
-
 		it("Adds itself to the overlays array", () => {
 			let testOverlay = new Overlay('myID', {html: 'hello'});
 			proclaim.strictEqual(Overlay.getOverlays()['myID'], testOverlay);
@@ -107,7 +107,9 @@ describe("Overlay", () => {
 			const testOverlay = new Overlay('myID', {html: 'hello'});
 			proclaim.strictEqual(document.body, testOverlay.context);
 		});
+	});
 
+	describe("Open", () => {
 		it("Does not add state to history when not in full screen mode.", () => {
 			const testOverlay = new Overlay('myID', { html: 'hello', fullscreen: false });
 			testOverlay.open();
@@ -177,6 +179,23 @@ describe("Overlay", () => {
 			}, 10);
 		});
 	});
+
+	describe("Realign", () => {
+		it("Adds a height to overlay content if the overlay is larger than the viewport.", () => {
+			const contentHeight = '3000px';
+			const testOverlay = new Overlay('contentHeightTest', { html: 'hello' });
+			testOverlay.open();
+			const overlayContent = document.querySelector('.o-overlay--contentHeightTest .o-overlay__content');
+			// Demo sets no modal content so the modal is within the viewport, no content height should be set.
+			proclaim.equal(overlayContent.style.height, '');
+			// Model content now makes the modal larger than the viewport.
+			overlayContent.innerHTML = `<div style="height:${contentHeight};">Very long content.</div>`;
+			// Calling `realign` will now set a height so modal content is scrollable.
+			testOverlay.realign();
+			proclaim.equal(overlayContent.style.height, contentHeight);
+		});
+	});
+
 });
 
 /* Functions to unit test

--- a/test/specs/o-overlay.test.js
+++ b/test/specs/o-overlay.test.js
@@ -120,7 +120,7 @@ describe("Overlay", () => {
 			const testOverlay = new Overlay('myID', { html: 'hello', fullscreen: false, modal: false });
 			testOverlay.open();
 			setTimeout(() => {
-				const overlfow = document.body.style.overflow;
+				const overlfow = document.documentElement.style.overflow;
 				proclaim.equal(overlfow, '');
 				done();
 			}, 10);
@@ -157,13 +157,13 @@ describe("Overlay", () => {
 		it("Disables document scrolling with an open modal overlay.", () => {
 			const testOverlay = new Overlay('modalScrollTest', { html: 'hello', modal: true, fullscreen: false});
 			testOverlay.open();
-			proclaim.equal(document.body.style.overflow, 'hidden');
+			proclaim.equal(document.documentElement.style.overflow, 'hidden');
 		});
 
 		it("Disables document scrolling with an open fullscreen overlay.", () => {
 			const testOverlay = new Overlay('fullscreenScrollTest', { html: 'hello', modal: false, fullscreen: true});
 			testOverlay.open();
-			proclaim.equal(document.body.style.overflow, 'hidden');
+			proclaim.equal(document.documentElement.style.overflow, 'hidden');
 		});
 
 		it("Adds custom classes to the overlay.", (done) => {


### PR DESCRIPTION
Clients sometimes change the content of the overlay after it is opened. In these cases the overlay can be mispositioned, and if the content of the overlay becomes larger than the viewport the content is inaccessible as it cannot be scrolled. Calling `realign` after overlay content has updated should correct this.

- Updates `origami.json` demo syntax to conform to the spec.
- Updates the `realign` method so its arguments are optional.
- Corrects some code documentation.
- Surfaces the `realign` method in the README.