### PR TITLE
Add whitelabel brand support.

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -2,7 +2,7 @@ $o-overlay-is-silent: false;
 @import "../../main";
 
 body {
-	font-family: MetricWeb;
+	font-family: if(oBrandGetCurrentBrand() == 'whitelabel', Arial, MetricWeb); // todo, use o-fonts or o-typography in the next major
 	padding: 10px;
 	min-height: 500px;
 }

--- a/origami.json
+++ b/origami.json
@@ -5,7 +5,8 @@
 	"origamiVersion": 1,
 	"brands" : [
 		"master",
-		"internal"
+		"internal",
+		"whitelabel"
 	],
 	"support": "https://github.com/Financial-Times/o-overlay/issues",
 	"supportContact": {

--- a/src/scss/_brand.scss
+++ b/src/scss/_brand.scss
@@ -47,3 +47,22 @@
 	),
 	'supports-variants': ()
 ));
+
+@include oBrandDefine('o-overlay', 'whitelabel', (
+	'variables': (
+		default-background: oColorsGetPaletteColor('white'),
+		default-border: oColorsGetPaletteColor('transparent'),
+		heading-background: oColorsGetPaletteColor('transparent'),
+		heading-text: oColorsGetPaletteColor('black-80'),
+		shaded-heading-background: oColorsGetPaletteColor('black'),
+		shaded-heading-border: oColorsGetPaletteColor('black'),
+		shaded-heading-text: oColorsGetPaletteColor('white'),
+		default-close-background: oColorsGetPaletteColor('white'),
+		default-close-text: oColorsGetPaletteColor('black'),
+		default-close-border: oColorsGetPaletteColor('black'),
+		shaded-close-background: oColorsGetPaletteColor('black'),
+		shaded-close-text: oColorsGetPaletteColor('white'),
+		shaded-close-border: oColorsGetPaletteColor('white')
+	),
+	'supports-variants': ()
+));


### PR DESCRIPTION
<img width="1210" alt="screenshot 2019-02-13 at 18 36 38" src="https://user-images.githubusercontent.com/10405691/52735053-9749d200-2fbe-11e9-99a3-703e33af976f.png">


The demo should include o-typography in the future: https://github.com/Financial-Times/o-overlay/issues/176