### PR TITLE
Remove o-hoverable.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "ftdomdelegate": "^2.0.1",
     "o-colors": "^4.0.0",
-    "o-hoverable": ">=0.2.0 <4",
     "o-icons": ">=4.0.0 <6.0.0",
     "o-normalise": "^1.2.1",
     "o-layers": ">=0.2.0 <3",

--- a/main.scss
+++ b/main.scss
@@ -5,7 +5,6 @@
 
 @import 'o-brand/main';
 @import 'o-colors/main';
-@import 'o-hoverable/main';
 @import 'o-normalise/main';
 @import 'o-icons/main';
 @import 'o-visual-effects/main';

--- a/origami.json
+++ b/origami.json
@@ -30,7 +30,6 @@
 	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"documentClasses": "o-hoverable-on",
 		"dependencies": [
 			"o-fonts@^3.0.0",
 			"o-buttons@^5.0.0",

--- a/src/scss/_shaded.scss
+++ b/src/scss/_shaded.scss
@@ -21,15 +21,19 @@
 	background-color: _oOverlayGet('shaded-close-background');
 	border-color: _oOverlayGet('shaded-close-border');
 
+	&:hover,
 	&:focus {
 		@include _oOverlayCloseIcon(_oOverlayGet('default-close-text'));
 		background-color: _oOverlayGet('default-close-background');
 	}
 
 	&:hover {
-		@media (hover) {
-			@include _oOverlayCloseIcon(_oOverlayGet('default-close-text'));
-			background-color: _oOverlayGet('default-close-background');
+		// Do not show the hover state to primarily touch based devices.
+		// IE11 does not support the hover media query, so we have to remove hover
+		// styles for touch devices rather than add them for non-touch.
+		@media (hover: none) {
+			background-image: unset; // Unset the icon. See _oOverlayCloseIcon.
+			background-color: unset;
 		}
 	}
 }

--- a/src/scss/_shaded.scss
+++ b/src/scss/_shaded.scss
@@ -26,14 +26,4 @@
 		@include _oOverlayCloseIcon(_oOverlayGet('default-close-text'));
 		background-color: _oOverlayGet('default-close-background');
 	}
-
-	&:hover {
-		// Do not show the hover state to primarily touch based devices.
-		// IE11 does not support the hover media query, so we have to remove hover
-		// styles for touch devices rather than add them for non-touch.
-		@media (hover: none) {
-			background-image: unset; // Unset the icon. See _oOverlayCloseIcon.
-			background-color: unset;
-		}
-	}
 }

--- a/src/scss/_shaded.scss
+++ b/src/scss/_shaded.scss
@@ -21,9 +21,15 @@
 	background-color: _oOverlayGet('shaded-close-background');
 	border-color: _oOverlayGet('shaded-close-border');
 
-	&:focus,
-	#{$o-hoverable-if-hover-enabled} &:hover {
+	&:focus {
 		@include _oOverlayCloseIcon(_oOverlayGet('default-close-text'));
 		background-color: _oOverlayGet('default-close-background');
+	}
+
+	&:hover {
+		@media (hover) {
+			@include _oOverlayCloseIcon(_oOverlayGet('default-close-text'));
+			background-color: _oOverlayGet('default-close-background');
+		}
 	}
 }


### PR DESCRIPTION
~As the close button is styled the same when focused or hovered there's no need for `o-hoverable` or `@media (hover)`.~

~Swaps `o-hoverable`  for the native [hover media query](https://drafts.csswg.org/mediaqueries-4/#hover). Removing so we can deprecate o-hoverable: https://github.com/Financial-Times/o-hoverable/issues/29~

Removes `o-hoverable`. The close button is immediately hidden on tap so there's no reason to hide the hover state for primarily touch based devices.