### PR TITLE
Allow version 2 or 3 of ftdomdelegate.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "test"
   ],
   "dependencies": {
-    "ftdomdelegate": "^2.0.1",
+    "ftdomdelegate": ">=2.2.0 <4.0.0",
     "o-colors": "^4.0.0",
     "o-icons": ">=4.0.0 <6.0.0",
     "o-normalise": "^1.2.1",


### PR DESCRIPTION
v3 of ftdomdelegate has the same api as v2. It was named
dom-delegate in its manifest files and v3 makes the name
consistent. It was also released (renamed) as v2.2.0 on npm.

https://github.com/Financial-Times/ftdomdelegate/pull/93