### PR TITLE
Only trap focus on visible and active elements

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -18,7 +18,6 @@
 	"keywords": "interstitial messaging modal popover notification hover",
 	"browserFeatures": {
 		"required": [
-			"array.from",
 			"es5object",
 			"es5string",
 			"classlist",

--- a/origami.json
+++ b/origami.json
@@ -18,6 +18,7 @@
 	"keywords": "interstitial messaging modal popover notification hover",
 	"browserFeatures": {
 		"required": [
+			"array.from",
 			"es5object",
 			"es5string",
 			"classlist",

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -66,9 +66,15 @@ const triggerClickHandler = function(id, ev) {
 	}
 };
 
+const isVisible = function (element) {
+	return !!element.offsetHeight;
+};
+
 const focusTrap = function(event) {
-	const overlayFocusableElements = this.wrapper.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
 	const tabKeyCode = 9;
+	const overlayFocusableElements = Array.from(
+		this.wrapper.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+	).filter(element => isVisible(element) && !element.disabled);
 
 	if (overlayFocusableElements.length && event.keyCode === tabKeyCode) {
 		const lastElement = overlayFocusableElements[overlayFocusableElements.length - 1];

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -72,7 +72,7 @@ const isVisible = function (element) {
 
 const focusTrap = function(event) {
 	const tabKeyCode = 9;
-	const overlayFocusableElements = Array.from(
+	const overlayFocusableElements = [].slice.call(
 		this.wrapper.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
 	).filter(element => isVisible(element) && !element.disabled);
 


### PR DESCRIPTION
The feedback component made us aware of times when the focus trap might
not work because of hidden elements tracked. This could cause the last
focusable element to never get focus.

This improvement means that it will only find elements that are visible
and not disabled.