### PR TITLE
Trap focus of overlays which end with form inputs.

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -34,7 +34,8 @@
 		"dependencies": [
 			"o-fonts@^3.0.0",
 			"o-buttons@^5.0.0",
-			"o-normalise@^1.0.0"
+			"o-normalise@^1.0.0",
+			"o-forms"
 		]
 	},
 	"demos": [

--- a/origami.json
+++ b/origami.json
@@ -34,8 +34,7 @@
 		"dependencies": [
 			"o-fonts@^3.0.0",
 			"o-buttons@^5.0.0",
-			"o-normalise@^1.0.0",
-			"o-forms"
+			"o-normalise@^1.0.0"
 		]
 	},
 	"demos": [

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -76,6 +76,9 @@ const focusTrap = function(event) {
 		this.wrapper.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
 	).filter(element => {
 		const elementVisible = isVisible(element);
+		// Inputs for radio and checkboxes are visually hidden, 
+		// so check the label visibility of inputs too when determining
+		// whether to trap focus.
 		const elementLabelVisible = element.labels && [].slice.call(element.labels).some(l => isVisible(l));
 		// When tabbing, the checked radio input of a group is focused, not each radio input.
 		const elementIsUncheckedRadio = element.type === 'radio' && element.checked !== true;

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -74,7 +74,13 @@ const focusTrap = function(event) {
 	const tabKeyCode = 9;
 	const overlayFocusableElements = [].slice.call(
 		this.wrapper.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
-	).filter(element => isVisible(element) && !element.disabled);
+	).filter(element => {
+		const elementVisible = isVisible(element);
+		const elementLabelVisible = element.labels && [].slice.call(element.labels).some(l => isVisible(l));
+		// When tabbing, the checked radio input of a group is focused, not each radio input.
+		const elementIsUncheckedRadio = element.type === 'radio' && element.checked !== true;
+		return !element.disabled && !elementIsUncheckedRadio && (elementVisible || elementLabelVisible);
+	});
 
 	if (overlayFocusableElements.length && event.keyCode === tabKeyCode) {
 		const lastElement = overlayFocusableElements[overlayFocusableElements.length - 1];

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -76,7 +76,7 @@ const focusTrap = function(event) {
 		this.wrapper.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
 	).filter(element => {
 		const elementVisible = isVisible(element);
-		// Inputs for radio and checkboxes are visually hidden, 
+		// Inputs for radio and checkboxes are visually hidden,
 		// so check the label visibility of inputs too when determining
 		// whether to trap focus.
 		const elementLabelVisible = element.labels && [].slice.call(element.labels).some(l => isVisible(l));


### PR DESCRIPTION
Visibility:

Inputs for radio and checkboxes are visually hidden, so check
the label visibility of inputs too when determining whether to
trap focus.

Radios:

When tabbing, the checked radio input of a group of radio inputs
is focused. To change the radio selection / focus the arrow keys
are used. Tabbing again takes focus to the next focusable element
after the radio group. Therefore focus must be trapped before
radio inputs which are not checked (as they do not receive
focus by tabbing).

![Kapture 2019-07-23 at 12 11 54](https://user-images.githubusercontent.com/10405691/61708303-68414480-ad44-11e9-9166-1980c58dc04c.gif)
