### PR TITLE
Update option "visuallyHideTitle" to "visuallyhide".

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ var myOverlay = new Overlay('myOverlay', {
 
 * `heading`: Object. Options for the Overlay header
 	* `.title`: String. Your overlay's title
-	* `.visuallyHideTitle`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling) _Default_: false.
+	* `.visuallyhide`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling) _Default_: false.
 	* `.shaded`: Boolean. Whether to shade the background of the header
 * `modal`: Boolean. Whether the overlay should have modal behaviour or not. This will add a translucent shadow between the page and the overlay. Modal overlays also disable scroll on the underlying document. _Default_: true.
 * `fullscreen`: Boolean. If set to true, the overlay will display full screen. This overlay disables scroll on the underlying document and is dismissible with the back button.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ var myOverlay = new Overlay('myOverlay', {
 
 * `heading`: Object. Options for the Overlay header
 	* `.title`: String. Your overlay's title
-	* `.visuallyhide`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling) _Default_: false.
+	* `.visuallyhidetitle`: Boolean. If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for `aria` labelling) _Default_: false.
 	* `.shaded`: Boolean. Whether to shade the background of the header
 * `modal`: Boolean. Whether the overlay should have modal behaviour or not. This will add a translucent shadow between the page and the overlay. Modal overlays also disable scroll on the underlying document. _Default_: true.
 * `fullscreen`: Boolean. If set to true, the overlay will display full screen. This overlay disables scroll on the underlying document and is dismissible with the back button.

--- a/demos/src/sliding-notification.js
+++ b/demos/src/sliding-notification.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded", function() {
 		compact: true,
 		preventclosing: false,
 		addclosebtn: true,
-		heading: { title: "Take a survey", visuallyhide: true },
+		heading: { title: "Take a survey", visuallyhidetitle: true },
 		html: `<div class='demo-overlay-content'><span class='title'>How do you rate FT.com?</span><p>Take our short survey and be in with a chance to win £250</p>
 					<button onclick="window.location.reload(true)" class="o-buttons o-buttons--standout">Take survey</button>
 					<p class="small">T&Cs apply</p></div>`

--- a/demos/src/sliding-notification.js
+++ b/demos/src/sliding-notification.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded", function() {
 		compact: true,
 		preventclosing: false,
 		addclosebtn: true,
-		heading: { title: "Take a survey", visuallyHideTitle: true },
+		heading: { title: "Take a survey", visuallyhide: true },
 		html: `<div class='demo-overlay-content'><span class='title'>How do you rate FT.com?</span><p>Take our short survey and be in with a chance to win £250</p>
 					<button onclick="window.location.reload(true)" class="o-buttons o-buttons--standout">Take survey</button>
 					<p class="small">T&Cs apply</p></div>`

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -34,6 +34,10 @@ const checkOptions = function(opts) {
 		console.warn('Please change the instantation of o-overlay to use the `nofocus` option instead of `noFocus`. `noFocus` will be removed in a future major version.');
 		opts.nofocus = opts.noFocus;
 	}
+	if (opts.visuallyHideTitle) {
+		console.warn('Please change the instantation of o-overlay to use the `visuallyhide` option instead of `visuallyHideTitle`. `visuallyHideTitle` will be removed in a future major version.');
+		opts.visuallyhide = opts.visuallyHideTitle;
+	}
 
 	return opts;
 };
@@ -104,7 +108,7 @@ const focusTrap = function(event) {
  * @param {HTMLElement} id - String. A unique identifier for the overlay within the page. (Required)
  * @param {Object} opts - An options object for configuring the Overlay. This object MUST have either `src` or `html` set. (Required)
  * @param {String} opts.heading.title - Your overlay's title
- * @param {Boolean} opts.heading.visuallyHideTitle - If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for aria labelling) Default: false.
+ * @param {Boolean} opts.heading.visuallyhide - If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for aria labelling) Default: false.
  * @param {Boolean} opts.heading.shaded - Whether to shade the background of the header. Default: to false
  * @param {Boolean} opts.modal - Whether the overlay should have modal behaviour or not. Setting this as true will add a translucent shadow between the page and the overlay
  * @param {Boolean} opts.compact - If true, the .o-overlay--compact class will be added to the overlay that reduces heading font-size and paddings in the content.
@@ -274,7 +278,7 @@ Overlay.prototype.render = function() {
 		title.setAttribute('role', 'heading');
 		title.className = 'o-overlay__title';
 
-		if (!this.opts.heading.visuallyHideTitle) {
+		if (!this.opts.heading.visuallyhide) {
 			title.innerHTML = this.opts.heading.title;
 		}
 

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -35,8 +35,8 @@ const checkOptions = function(opts) {
 		opts.nofocus = opts.noFocus;
 	}
 	if (opts.visuallyHideTitle) {
-		console.warn('Please change the instantation of o-overlay to use the `visuallyhide` option instead of `visuallyHideTitle`. `visuallyHideTitle` will be removed in a future major version.');
-		opts.visuallyhide = opts.visuallyHideTitle;
+		console.warn('Please change the instantation of o-overlay to use the `visuallyhidetitle` option instead of `visuallyHideTitle`. `visuallyHideTitle` will be removed in a future major version.');
+		opts.visuallyhidetitle = opts.visuallyHideTitle;
 	}
 
 	return opts;
@@ -108,7 +108,7 @@ const focusTrap = function(event) {
  * @param {HTMLElement} id - String. A unique identifier for the overlay within the page. (Required)
  * @param {Object} opts - An options object for configuring the Overlay. This object MUST have either `src` or `html` set. (Required)
  * @param {String} opts.heading.title - Your overlay's title
- * @param {Boolean} opts.heading.visuallyhide - If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for aria labelling) Default: false.
+ * @param {Boolean} opts.heading.visuallyhidetitle - If you want to provide a different title style, this option will prevent the title span from being added to the overlay. (In this case the title is only used for aria labelling) Default: false.
  * @param {Boolean} opts.heading.shaded - Whether to shade the background of the header. Default: to false
  * @param {Boolean} opts.modal - Whether the overlay should have modal behaviour or not. Setting this as true will add a translucent shadow between the page and the overlay
  * @param {Boolean} opts.compact - If true, the .o-overlay--compact class will be added to the overlay that reduces heading font-size and paddings in the content.
@@ -278,7 +278,7 @@ Overlay.prototype.render = function() {
 		title.setAttribute('role', 'heading');
 		title.className = 'o-overlay__title';
 
-		if (!this.opts.heading.visuallyhide) {
+		if (!this.opts.heading.visuallyhidetitle) {
 			title.innerHTML = this.opts.heading.title;
 		}
 


### PR DESCRIPTION
- Deprecates `visuallyHideTitle` config.
- Supports visually hiding the overlay heading declarative.

Details: https://github.com/Financial-Times/o-overlay/issues/199