### PR TITLE
Fix headingId value assignment regex

### DIFF
--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -243,7 +243,7 @@ class Overlay {
 
 		if (this.opts.heading) {
 			const heading = document.createElement('header');
-			const headingId = this.opts.heading.title.replace(' ', '-').toLowerCase();
+			const headingId = this.opts.heading.title.replace(/\s+/g, '-').toLowerCase();
 			heading.classList.add('o-overlay__heading');
 			heading.setAttribute('id', headingId);
 			wrapperEl.setAttribute('aria-labelledby', headingId);


### PR DESCRIPTION
The regex used when assigning a headingId value can currently only copy with a single whitespace.

For any value with more than one whitespace, this is the result (`Copy to list` gets turned into `copy-to list`, with the additional whitespace persisting):

<img width="1095" alt="Screenshot 2020-01-09 at 16 08 46" src="https://user-images.githubusercontent.com/10484515/72083908-71c26700-32fa-11ea-8267-31b89582500d.png">

This PR ensures that the regex will convert all whitespace to hyphens.