### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/specs/o-overlay.test.js
+++ b/test/specs/o-overlay.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* global proclaim sinon */
+
 import * as fixtures from '../helpers/fixtures';
 
 import oLayers from 'o-layers';

--- a/test/specs/origami.test.js
+++ b/test/specs/origami.test.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* global proclaim sinon */
+
 import * as fixtures from '../helpers/fixtures';
 
 import Overlay from './../../main';

--- a/test/specs/smoke.test.js
+++ b/test/specs/smoke.test.js
@@ -1,9 +1,8 @@
 /* eslint-env mocha */
+/* global proclaim sinon */
 
 import * as o from '../helpers/events';
 import Overlay from '../../src/js/overlay';
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
 
 const testContent = '<div class="test-overlay"><span class="test-overlay__text">Hello Overlay</span></div>';
 


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.