### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/sliding-notification.js
+++ b/demos/src/sliding-notification.js
@@ -1,4 +1,4 @@
-import Overlay from '../../main';
+import Overlay from '../../main.js';
 
 document.addEventListener("DOMContentLoaded", function() {
 	const myOverlay = new Overlay('demo-overlay', {

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 
-import Overlay from './src/js/overlay';
+import Overlay from './src/js/overlay.js';
 
 const constructAll = function() {
 	Overlay.init();

--- a/src/js/overlay.js
+++ b/src/js/overlay.js
@@ -1,7 +1,7 @@
 import Delegate from 'ftdomdelegate';
 import viewport from 'o-viewport';
 import oLayers from 'o-layers';
-import utils from './utils';
+import utils from './utils.js';
 const overlays = {};
 
 const checkOptions = function(opts) {

--- a/test/specs/o-overlay.test.js
+++ b/test/specs/o-overlay.test.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from '../helpers/fixtures';
+import * as fixtures from '../helpers/fixtures.js';
 
 import oLayers from 'o-layers';
-import Overlay from './../../main';
+import Overlay from './../../main.js';
 
 describe("Overlay", () => {
 

--- a/test/specs/origami.test.js
+++ b/test/specs/origami.test.js
@@ -1,9 +1,9 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as fixtures from '../helpers/fixtures';
+import * as fixtures from '../helpers/fixtures.js';
 
-import Overlay from './../../main';
+import Overlay from './../../main.js';
 
 describe("Overlay", () => {
 	it('is defined', () => {

--- a/test/specs/smoke.test.js
+++ b/test/specs/smoke.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import * as o from '../helpers/events';
-import Overlay from '../../src/js/overlay';
+import * as o from '../helpers/events.js';
+import Overlay from '../../src/js/overlay.js';
 
 const testContent = '<div class="test-overlay"><span class="test-overlay__text">Hello Overlay</span></div>';
 


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing